### PR TITLE
feat(compiler): introduce macro `impl_tests` for generating arithmetic tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "hex",
+ "paste",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/codegen/src/abi.rs
+++ b/codegen/src/abi.rs
@@ -92,6 +92,7 @@ macro_rules! offset {
 
 offset! {
     (usize, 8),
+    (i64, 8),
     (i32, 4),
     (u32, 4),
     (u16, 2),

--- a/codegen/src/masm/integer.rs
+++ b/codegen/src/masm/integer.rs
@@ -17,8 +17,9 @@ impl MacroAssembler {
     }
 
     /// Push a 64-bit integer value on the stack.
-    pub fn _i64_const(&mut self, _value: i64) -> Result<()> {
-        todo!()
+    pub fn _i64_const(&mut self, value: i64) -> Result<()> {
+        self.push(value.to_ls_bytes().as_ref())?;
+        Ok(())
     }
 
     /// Push a 32-bit float value on the stack.

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -21,3 +21,4 @@ hex.workspace = true
 wat.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"]}
 zint.workspace = true
+paste.workspace = true

--- a/compiler/tests/add.rs
+++ b/compiler/tests/add.rs
@@ -6,9 +6,8 @@ use zint::{Bytes32, EVM};
 
 mod common;
 
-#[test]
-fn params() -> Result<()> {
-    let bytecode = common::load("i32add", "params")?;
+fn params(module: &str) -> Result<()> {
+    let bytecode = common::load(module, "params")?;
 
     // add(1, 2)
     let input = [1.to_bytes32(), 2.to_bytes32()].concat();
@@ -18,20 +17,23 @@ fn params() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn locals() -> Result<()> {
-    let bytecode = common::load("i32add", "locals")?;
+fn locals(module: &str) -> Result<()> {
+    let bytecode = common::load(module, "locals")?;
     let info = EVM::run(&bytecode, &[]);
 
     assert_eq!(info.ret, [30.to_bytes32()].concat());
     Ok(())
 }
 
-#[test]
-fn tee() -> Result<()> {
-    let bytecode = common::load("i32add", "tee")?;
+fn tee(module: &str) -> Result<()> {
+    let bytecode = common::load(module, "tee")?;
     let info = EVM::run(&bytecode, &[]);
 
     assert_eq!(info.ret, [30.to_bytes32()].concat());
     Ok(())
+}
+
+impl_tests! {
+    tests: [params, locals, tee],
+    modules: ["i32add", "i64add"]
 }

--- a/compiler/tests/common/macros.rs
+++ b/compiler/tests/common/macros.rs
@@ -1,0 +1,23 @@
+//! Shared macros
+
+#[macro_export]
+macro_rules! impl_tests {
+    (
+        tests: [$($test:ident),+],
+        modules: $modules:tt
+    ) => {
+        $(
+            impl_tests!(@test $test $modules);
+        )*
+    };
+    (@test $test:ident [$($mod:expr),*]) => {
+        $(
+            paste::paste! {
+                #[test]
+                fn [<$mod _ $test>]() -> anyhow::Result<()> {
+                    $test($mod)
+                }
+            }
+        )*
+    };
+}

--- a/compiler/tests/common/mod.rs
+++ b/compiler/tests/common/mod.rs
@@ -7,6 +7,8 @@ use tracing_subscriber::EnvFilter;
 use wat;
 use zinkc::Compiler;
 
+mod macros;
+
 fn setup_logger() {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())

--- a/compiler/tests/storage.rs
+++ b/compiler/tests/storage.rs
@@ -6,8 +6,8 @@ use zint::{Bytes32, InstructionResult, EVM};
 
 mod common;
 
-#[test]
 #[ignore]
+#[test]
 fn basic() -> Result<()> {
     let bytecode = common::load("storage", "basic")?;
     let info = EVM::run(&bytecode, &42.to_bytes32());

--- a/compiler/tests/storage.rs
+++ b/compiler/tests/storage.rs
@@ -1,0 +1,19 @@
+//! storage tests
+#![cfg(test)]
+
+use anyhow::Result;
+use zint::{Bytes32, InstructionResult, EVM};
+
+mod common;
+
+#[test]
+#[ignore]
+fn basic() -> Result<()> {
+    let bytecode = common::load("storage", "basic")?;
+    let info = EVM::run(&bytecode, &42.to_bytes32());
+
+    assert_eq!(info.instr, InstructionResult::Return);
+    assert_eq!(info.ret, 42.to_bytes32());
+
+    Ok(())
+}

--- a/compiler/tests/sub.rs
+++ b/compiler/tests/sub.rs
@@ -6,9 +6,8 @@ use zint::{Bytes32, EVM};
 
 mod common;
 
-#[test]
-fn params() -> Result<()> {
-    let bytecode = common::load("i32sub", "params")?;
+fn params(module: &str) -> Result<()> {
+    let bytecode = common::load(module, "params")?;
 
     // add(1, 2)
     let input = [2.to_bytes32(), 1.to_bytes32()].concat();
@@ -18,11 +17,15 @@ fn params() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn locals() -> Result<()> {
-    let bytecode = common::load("i32sub", "locals")?;
+fn locals(module: &str) -> Result<()> {
+    let bytecode = common::load(module, "locals")?;
     let info = EVM::run(&bytecode, &[]);
 
     assert_eq!(info.ret, [10.to_bytes32()].concat());
     Ok(())
+}
+
+impl_tests! {
+    tests: [params, locals],
+    modules: ["i32sub", "i64sub"]
 }

--- a/compiler/wat/i64add/locals.wat
+++ b/compiler/wat/i64add/locals.wat
@@ -1,0 +1,16 @@
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 10)
+        (local.set $foo)
+
+        (i64.const 20)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        i64.add
+    )
+)

--- a/compiler/wat/i64add/params.wat
+++ b/compiler/wat/i64add/params.wat
@@ -1,0 +1,7 @@
+(module
+    (func (param i64) (param i64) (result i64)
+    (local.get 0)
+    (local.get 1)
+    (i64.add)
+    )
+)

--- a/compiler/wat/i64add/tee.wat
+++ b/compiler/wat/i64add/tee.wat
@@ -1,0 +1,15 @@
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 10)
+        (local.tee $foo)
+
+        (i64.const 20)
+        (local.set $bar)
+
+        (local.get $bar)
+        i64.add
+    )
+)

--- a/compiler/wat/i64sub/locals.wat
+++ b/compiler/wat/i64sub/locals.wat
@@ -1,16 +1,16 @@
 (module
-    (func (result i32)
-        (local $foo i32)
-        (local $bar i32)
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
 
-        (i32.const 20)
+        (i64.const 20)
         (local.set $foo)
 
-        (i32.const 10)
+        (i64.const 10)
         (local.set $bar)
 
         (local.get $foo)
         (local.get $bar)
-        i32.sub
+        i64.sub
     )
 )

--- a/compiler/wat/i64sub/locals.wat
+++ b/compiler/wat/i64sub/locals.wat
@@ -1,0 +1,16 @@
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 20)
+        (local.set $foo)
+
+        (i32.const 10)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        i32.sub
+    )
+)

--- a/compiler/wat/i64sub/params.wat
+++ b/compiler/wat/i64sub/params.wat
@@ -1,0 +1,7 @@
+(module
+    (func (param i32) (param i32) (result i32)
+    (local.get 0)
+    (local.get 1)
+    (i32.sub)
+    )
+)

--- a/compiler/wat/i64sub/params.wat
+++ b/compiler/wat/i64sub/params.wat
@@ -1,7 +1,7 @@
 (module
-    (func (param i32) (param i32) (result i32)
+    (func (param i64) (param i64) (result i64)
     (local.get 0)
     (local.get 1)
-    (i32.sub)
+    (i64.sub)
     )
 )

--- a/compiler/wat/storage/basic.wat
+++ b/compiler/wat/storage/basic.wat
@@ -1,0 +1,32 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (result i32)))
+  (func $set_and_get (type 0) (param i32) (result i32)
+    i32.const 1048572
+    local.get 0
+    i32.store
+    i32.const 1048576
+    local.get 0
+    i32.store
+    i32.const 1048576
+    i32.load)
+  (func $set (type 1) (param i32)
+    i32.const 1048572
+    local.get 0
+    i32.store
+    i32.const 1048576
+    local.get 0
+    i32.store)
+  (func $get (type 2) (result i32)
+    i32.const 1048576
+    i32.load)
+  (memory (;0;) 17)
+  (global (;0;) i32 (i32.const 1048580))
+  (global (;1;) i32 (i32.const 1048592))
+  (export "memory" (memory 0))
+  (export "set_and_get" (func $set_and_get))
+  (export "set" (func $set))
+  (export "get" (func $get))
+  (export "__data_end" (global 0))
+  (export "__heap_base" (global 1)))

--- a/compiler/wat/storage/basic.wat
+++ b/compiler/wat/storage/basic.wat
@@ -1,32 +1,29 @@
 (module
-  (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i32)))
-  (type (;2;) (func (result i32)))
-  (func $set_and_get (type 0) (param i32) (result i32)
-    i32.const 1048572
+  (type (;0;) (func (param i64) (result i64)))
+  (type (;1;) (func (param i64 i64)))
+  (type (;2;) (func (param i64)))
+  (type (;3;) (func (result i64)))
+  (import "zink" "sstore" (func (;0;) (type 1)))
+  (import "zink" "sload" (func (;1;) (type 0)))
+  (func (;2;) (type 0) (param i64) (result i64)
+    i64.const 0
     local.get 0
-    i32.store
-    i32.const 1048576
+    call 0
+    i64.const 0
+    call 1)
+  (func (;3;) (type 2) (param i64)
+    i64.const 0
     local.get 0
-    i32.store
-    i32.const 1048576
-    i32.load)
-  (func $set (type 1) (param i32)
-    i32.const 1048572
-    local.get 0
-    i32.store
-    i32.const 1048576
-    local.get 0
-    i32.store)
-  (func $get (type 2) (result i32)
-    i32.const 1048576
-    i32.load)
-  (memory (;0;) 17)
-  (global (;0;) i32 (i32.const 1048580))
-  (global (;1;) i32 (i32.const 1048592))
+    call 0)
+  (func (;4;) (type 3) (result i64)
+    i64.const 0
+    call 1)
+  (memory (;0;) 16)
+  (global (;0;) i32 (i32.const 1048576))
+  (global (;1;) i32 (i32.const 1048576))
   (export "memory" (memory 0))
-  (export "set_and_get" (func $set_and_get))
-  (export "set" (func $set))
-  (export "get" (func $get))
+  (export "set_and_get" (func 2))
+  (export "set" (func 3))
+  (export "get" (func 4))
   (export "__data_end" (global 0))
   (export "__heap_base" (global 1)))

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -24,5 +24,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "zink"
+name = "storage"
 version = "0.1.0"
+dependencies = [
+ "zink",
+]
+
+[[package]]
+name = "zink"
+version = "0.1.2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,8 @@ resolver = "2"
 members = [
   "addition",
   "fibonacci",
-  "if-else"
+  "if-else",
+  "storage"
 ]
 
 [workspace.dependencies]

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zink.workspace = true

--- a/examples/storage/src/lib.rs
+++ b/examples/storage/src/lib.rs
@@ -5,23 +5,36 @@
 #[cfg(not(test))]
 extern crate zink;
 
-static mut COUNTER: i32 = 0;
+use zink::storage::{sload, sstore};
+
+/// TODO: generate this storage interface with proc macro.
+struct Counter;
+
+impl Counter {
+    fn get() -> i64 {
+        unsafe { sload(0) }
+    }
+
+    fn set(value: i64) {
+        unsafe { sstore(0, value) }
+    }
+}
 
 /// Set value to storage and get it
 #[no_mangle]
-pub unsafe extern "C" fn set_and_get(x: i32) -> i32 {
-    COUNTER = x;
-    COUNTER
+pub unsafe extern "C" fn set_and_get(value: i64) -> i64 {
+    Counter::set(value);
+    Counter::get()
 }
 
 /// Set value to storage
 #[no_mangle]
-pub unsafe extern "C" fn set(x: i32) {
-    COUNTER = x;
+pub unsafe extern "C" fn set(value: i64) {
+    Counter::set(value);
 }
 
 /// Get value from storage
 #[no_mangle]
-pub unsafe extern "C" fn get() -> i32 {
-    COUNTER
+pub unsafe extern "C" fn get() -> i64 {
+    Counter::get()
 }

--- a/examples/storage/src/lib.rs
+++ b/examples/storage/src/lib.rs
@@ -1,0 +1,27 @@
+//! Addition example.
+#![no_std]
+
+// for the panic handler.
+#[cfg(not(test))]
+extern crate zink;
+
+static mut COUNTER: i32 = 0;
+
+/// Set value to storage and get it
+#[no_mangle]
+pub unsafe extern "C" fn set_and_get(x: i32) -> i32 {
+    COUNTER = x;
+    COUNTER
+}
+
+/// Set value to storage
+#[no_mangle]
+pub unsafe extern "C" fn set(x: i32) {
+    COUNTER = x;
+}
+
+/// Get value from storage
+#[no_mangle]
+pub unsafe extern "C" fn get() -> i32 {
+    COUNTER
+}

--- a/zink/src/imports.rs
+++ b/zink/src/imports.rs
@@ -1,0 +1,18 @@
+//! WASM module imports
+
+// Zink provided interfaces
+#[link(wasm_import_module = "zink")]
+extern "C" {
+    // i64 -> 8 bytes
+
+    /// Store a value in the storage
+    pub fn sstore(
+        // Storage key
+        key: i64,
+        // value key
+        value: i64,
+    );
+
+    /// Load a value from the storage
+    pub fn sload(key: i64) -> i64;
+}

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -1,5 +1,13 @@
 #![no_std]
 
+mod imports;
+
+/// Storage interfaces
+pub mod storage {
+    pub use super::imports::{sload, sstore};
+}
+
+// Panic hook implementation
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {


### PR DESCRIPTION
Part of #77 
Part of #92 

### Changes

- [x] introduce example storage
- [x] introduce macro `impl_tests` for generating arithmetic tests
- [x] i64 addition tests
- [x] i64 subtraction tests
- [ ] ~~implement `i32.load` related operand~~
- [ ] ~~pass the test~~


