### PR TITLE
refactor(codegen): embed storage related functions

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -6,10 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  TERM: xterm-256color
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: typos-action
-        uses: crate-ci/typos@v1.0.4
+      - uses: actions/checkout@v3
+      - uses: crate-ci/typos@v1.0.4

--- a/codegen/src/asm.rs
+++ b/codegen/src/asm.rs
@@ -18,7 +18,7 @@ pub struct Assembler {
     gas: u128,
     /// Memory pointer for byte offset.
     pub mp: usize,
-    /// Stack pointer, maximum 12 items.
+    /// Stack pointer, maximum 1024 items.
     pub sp: u8,
 }
 
@@ -43,6 +43,8 @@ impl Assembler {
     /// Increment stack pointer
     pub fn increment_sp(&mut self, items: u8) -> Result<()> {
         self.sp += items;
+
+        // TODO: fix this limitation: should be 1024.
         if self.sp > 12 {
             return Err(Error::StackOverflow(self.sp));
         }

--- a/codegen/src/func.rs
+++ b/codegen/src/func.rs
@@ -64,7 +64,7 @@ impl Func {
         }
     }
 
-    /// Pre-porcessing for the function.
+    /// Pre-processing for the function.
     pub fn prelude(&self, masm: &mut MacroAssembler) -> Result<()> {
         match self {
             Self::Select => {

--- a/codegen/src/func.rs
+++ b/codegen/src/func.rs
@@ -1,4 +1,5 @@
 //! Built-in functions for EVM
+use crate::{Error, MacroAssembler, Result};
 use opcodes::ShangHai as OpCode;
 
 /// Selects one of its first two operands based on whether
@@ -23,7 +24,7 @@ const SLOAD: [OpCode; 7] = [
     OpCode::JUMP,
 ];
 
-/// Function `sload` from EVM which is not available in WASM.
+/// Function `sstore` from EVM which is not available in WASM.
 const SSTORE: [OpCode; 6] = [
     OpCode::JUMPDEST,
     OpCode::SSTORE,
@@ -45,6 +46,20 @@ pub enum Func {
 }
 
 impl Func {
+    /// Pre-porcessing for the function.
+    pub fn prelude(&self, masm: &mut MacroAssembler) -> Result<()> {
+        match self {
+            Self::Select => {
+                masm._pc()?;
+                masm._swap2()?;
+                masm._swap1()?;
+                masm.asm.increment_sp(1)
+            }
+            Self::Sload => masm._swap1(),
+            Self::Sstore => masm._swap2(),
+        }
+    }
+
     /// Get the bytecode of the function.
     pub fn bytecode(&self) -> Vec<u8> {
         match self {
@@ -56,16 +71,31 @@ impl Func {
         .map(|op| op.into())
         .collect()
     }
+
+    /// If this function should be embedded in
+    /// the main code.
+    ///
+    /// TODO: return `false` for functions that
+    /// are necessary to just stay in the code
+    /// section #109
+    pub fn is_embedded(&self) -> bool {
+        match self {
+            Self::Select => true,
+            Self::Sload => true,
+            Self::Sstore => true,
+        }
+    }
 }
 
 impl TryFrom<(&str, &str)> for Func {
-    type Error = ();
+    type Error = Error;
 
-    fn try_from(import: (&str, &str)) -> Result<Self, Self::Error> {
+    fn try_from(import: (&str, &str)) -> Result<Self> {
+        let (module, name) = import;
         match import {
             ("zink", "sload") => Ok(Self::Sload),
             ("zink", "sstore") => Ok(Self::Sstore),
-            _ => Err(()),
+            _ => Err(Error::HostFuncNotFound(module.into(), name.into())),
         }
     }
 }

--- a/codegen/src/func.rs
+++ b/codegen/src/func.rs
@@ -46,14 +46,31 @@ pub enum Func {
 }
 
 impl Func {
+    /// Stack input size.
+    pub fn stack_in(&self) -> u8 {
+        match self {
+            Self::Select => 3,
+            Self::Sload => 1,
+            Self::Sstore => 2,
+        }
+    }
+
+    /// Stack output size.
+    pub fn stack_out(&self) -> u8 {
+        match self {
+            Self::Select => 1,
+            Self::Sload => 1,
+            Self::Sstore => 0,
+        }
+    }
+
     /// Pre-porcessing for the function.
     pub fn prelude(&self, masm: &mut MacroAssembler) -> Result<()> {
         match self {
             Self::Select => {
                 masm._pc()?;
                 masm._swap2()?;
-                masm._swap1()?;
-                masm.asm.increment_sp(1)
+                masm._swap1()
             }
             Self::Sload => masm._swap1(),
             Self::Sstore => masm._swap2(),

--- a/codegen/src/masm/embed.rs
+++ b/codegen/src/masm/embed.rs
@@ -1,0 +1,15 @@
+//! Embedded Function implementations
+
+use crate::{MacroAssembler, Result};
+
+impl MacroAssembler {
+    /// Function `sstore` from EVM which is not available in WASM.
+    pub fn _sstore(&mut self) -> Result<()> {
+        self.asm._sstore()
+    }
+
+    /// Function `sload` from EVM which is not available in WASM.
+    pub fn _sload(&mut self) -> Result<()> {
+        self.asm._sload()
+    }
+}

--- a/codegen/src/masm/mod.rs
+++ b/codegen/src/masm/mod.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use std::ops::{Deref, DerefMut};
 
 mod cmp;
+mod embed;
 mod float;
 mod integer;
 mod memory;

--- a/codegen/src/result.rs
+++ b/codegen/src/result.rs
@@ -18,15 +18,18 @@ pub enum Error {
     /// Failed to merge jump table.
     #[error("Program counter {0} already exists in jump table")]
     DuplicateJump(u16),
-    /// Failed to find imported function by index in jump table.
-    #[error("Imported Function {0} not found in jump table")]
-    ImportedFuncNotFound(u32),
-    /// Failed to find function index in jump table.
-    #[error("Function {0} not found in jump table")]
-    FuncNotFound(u32),
     /// Failed to find ext function index in jump table.
     #[error("External function {0:?} not found in jump table")]
     ExtNotFound(crate::Func),
+    /// Failed to find function index in jump table.
+    #[error("Function {0} not found in jump table")]
+    FuncNotFound(u32),
+    /// Failed to find host function in compiler.
+    #[error("Host function {0}::{1} not found in compiler")]
+    HostFuncNotFound(String, String),
+    /// Failed to find imported function by index in jump table.
+    #[error("Imported Function {0} not found in jump table")]
+    ImportedFuncNotFound(u32),
     /// Failed to mark else block for if block.
     #[error("Invalid else block for if block at {0}")]
     InvalidElseBlock(u16),
@@ -66,6 +69,9 @@ pub enum Error {
     /// Failed to pop stack.
     #[error("Stack not balanced, current stack items {0}")]
     StackNotBalanced(u8),
+    /// Failed to queue host functions.
+    #[error("Unsupported host function {0:?}")]
+    UnsupportedHostFunc(crate::Func),
 }
 
 /// Codegen result

--- a/codegen/src/visitor/control.rs
+++ b/codegen/src/visitor/control.rs
@@ -90,14 +90,12 @@ impl CodeGen {
     /// STACK: [val1, val2, cond] -> [val1] if cond is non-zero, [val2] otherwise.
     pub fn _select(&mut self) -> Result<()> {
         tracing::trace!("select");
-        self.masm._pc()?;
-        self.masm._swap2()?;
-        self.masm._swap1()?;
-        self.masm.asm.increment_sp(1)?;
+        let func = Func::Select;
+        func.prelude(&mut self.masm)?;
+
         self.table.ext(self.masm.pc_offset(), Func::Select);
         self.masm._jumpi()?;
         self.masm._jumpdest()?;
-
         Ok(())
     }
 

--- a/codegen/src/visitor/control.rs
+++ b/codegen/src/visitor/control.rs
@@ -92,10 +92,14 @@ impl CodeGen {
         tracing::trace!("select");
         let func = Func::Select;
         func.prelude(&mut self.masm)?;
+        self.masm.decrement_sp(func.stack_in())?;
 
+        // This if for pushing the PC of jumpdest.
+        self.masm.increment_sp(1)?;
         self.table.ext(self.masm.pc_offset(), Func::Select);
         self.masm._jumpi()?;
         self.masm._jumpdest()?;
+        self.masm.increment_sp(func.stack_out())?;
         Ok(())
     }
 

--- a/codegen/src/visitor/system.rs
+++ b/codegen/src/visitor/system.rs
@@ -78,8 +78,10 @@ impl CodeGen {
     /// Call external functions
     pub fn call_external(&mut self, func: Func) -> Result<()> {
         self.table.ext(self.masm.pc_offset(), func);
+        self.masm.decrement_sp(func.stack_in())?;
         self.masm._jump()?;
         self.masm._jumpdest()?;
+        self.masm.increment_sp(func.stack_out())?;
         Ok(())
     }
 }

--- a/docs/benchmarks/storage.md
+++ b/docs/benchmarks/storage.md
@@ -3,10 +3,7 @@
 Result for a simple storage IO.
 
 Have to say `Vyper` is super on this even it contains the logic of function
-selector! However we just found that the extended functions in zink could
-be optimized after doing research on the compiled bytecode from vyper.
-
-Issue: [zink-lang/zink#104][104]
+selector!
 
 ### Gas Cost
 

--- a/docs/benchmarks/storage.md
+++ b/docs/benchmarks/storage.md
@@ -12,7 +12,7 @@ Issue: [zink-lang/zink#104][104]
 
 | io  | Zink  | Vyper@0.3.9 | Solidity@0.8.21 |
 | --- | ----- | ----------- | --------------- |
-| 42  | 22294 | 22345       | 27738           |
+| 42  | 22237 | 22345       | 27738           |
 
 The gas costs here are measured by `transaction cost` + `execution cost`,
 for example, the transaction of this function in solidity is `24120`, and
@@ -27,7 +27,7 @@ Issues: [zink-lang/zink#102][102], [bluealloy/revm#619][619]
 
 | zink | vyper | solidity |
 | ---- | ----- | -------- |
-| 80   | 204   | 724      |
+| 42   | 204   | 724      |
 
 ## `zink`
 
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn set_and_get(value: i64) -> i64 {
 ```
 
 ```
-60006000355891601b565b600058906021565b60005260206000f35b55600501565b549060050156
+6000600035589155600058905460005260206000f3
 ```
 
 ## `vyper`

--- a/zink/src/imports.rs
+++ b/zink/src/imports.rs
@@ -1,6 +1,8 @@
 //! WASM module imports
 
 // Zink provided interfaces
+//
+// TODO: Align to 256-bit #20.
 #[link(wasm_import_module = "zink")]
 extern "C" {
     // i64 -> 8 bytes
@@ -15,4 +17,19 @@ extern "C" {
 
     /// Load a value from the storage
     pub fn sload(key: i64) -> i64;
+
+    /// Append log record with no topics
+    pub fn log0(offset: i64, size: i64);
+
+    /// Append log record with one topics
+    pub fn log1(offset: i64, size: i64);
+
+    /// Append log record with two topics
+    pub fn log2(offset: i64, size: i64);
+
+    /// Append log record with three topics
+    pub fn log3(offset: i64, size: i64);
+
+    /// Append log record with four topics
+    pub fn log4(offset: i64, size: i64);
 }

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -7,6 +7,11 @@ pub mod storage {
     pub use super::imports::{sload, sstore};
 }
 
+/// Event interfaces
+pub mod events {
+    pub use super::imports::{log0, log1, log2, log3, log4};
+}
+
 // Panic hook implementation
 #[cfg(not(test))]
 #[panic_handler]


### PR DESCRIPTION
Part of #107 
Resolves #104 

### Changes

- [x] introduce `log0..log4` in `zink`
- [x] fix typo checks btw
- [ ] implement `logx` in `codegen`
- [ ] support logs in `zint`
- [ ] example in docs
- [ ] bump version
- [x] embed storage related functions
- [x] provide stack IO for extended functions
- [x] update the result of zink for the storage benchmark

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
