### PR TITLE
feat(zink-codegen): introduce proc-macro for the event interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,14 @@ name = "zink"
 version = "0.1.3"
 
 [[package]]
+name = "zink-codegen"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "zinkc"
 version = "0.1.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,10 +2328,13 @@ dependencies = [
 [[package]]
 name = "zink"
 version = "0.1.3"
+dependencies = [
+ "zink-codegen",
+]
 
 [[package]]
 name = "zink-codegen"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "quote",
  "syn 2.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "compiler",
   "utils/*",
   "zink",
+  "zink/codegen",
   "zint"
 ]
 resolver = "2"
@@ -30,10 +31,12 @@ etc = "0.1.16"
 hex = "0.4.3"
 indexmap = "2.0.0"
 paste = "1.0.13"
+quote = "1.0.33"
 revm = "3.3.0"
 semver = "1.0.18"
 serde = "1.0.171"
 smallvec = "1.11.0"
+syn =  { version = "2.0.37", features = [ "full" ] }
 target-lexicon = "0.12.8"
 thiserror = "1.0.40"
 toml = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ opcodes = { package = "evm-opcodes", path = "codegen/opcodes", version = "=0.0.3
 zingen =  { path = "codegen", version = "=0.1.3" }
 zinkc = { path = "compiler", version = "=0.1.3" }
 zink = { path = "zink", version = "=0.1.3" }
+zink-codegen = { path = "zink/codegen", version = "=0.1.3" }
 zint = { path = "zint", version = "=0.1.3" }
 
 [profile]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -31,6 +31,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "storage"
 version = "0.1.0"
 dependencies = [
@@ -38,5 +56,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "zink"
 version = "0.1.3"
+dependencies = [
+ "zink-codegen",
+]
+
+[[package]]
+name = "zink-codegen"
+version = "0.1.3"
+dependencies = [
+ "quote",
+ "syn",
+]

--- a/examples/log/src/lib.rs
+++ b/examples/log/src/lib.rs
@@ -8,14 +8,8 @@ extern crate zink;
 use zink::Event;
 
 /// A `Ping` event.
-///
-/// TODO: generate this with proc-macro.
+#[derive(Event)]
 struct Ping;
-
-/// TODO: generate this with proc-macro.
-impl Event for Ping {
-    const NAME: &'static [u8] = b"Ping";
-}
 
 #[no_mangle]
 pub extern "C" fn log0() {

--- a/zink/Cargo.toml
+++ b/zink/Cargo.toml
@@ -8,3 +8,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+
+[dependencies]
+zink-codegen.workspace = true

--- a/zink/codegen/Cargo.toml
+++ b/zink/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zink-codegen"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/zink/codegen/Cargo.toml
+++ b/zink/codegen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zink-codegen"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn.workspace = true
+quote.workspace = true

--- a/zink/codegen/README.md
+++ b/zink/codegen/README.md
@@ -1,0 +1,1 @@
+## Code generation library for zink APIs

--- a/zink/codegen/src/event.rs
+++ b/zink/codegen/src/event.rs
@@ -1,0 +1,19 @@
+//! Event interface generation
+
+use proc_macro::{Span, TokenStream};
+use quote::quote;
+use syn::{DeriveInput, LitByteStr};
+
+/// Expand the event interface
+pub fn parse(item: DeriveInput) -> TokenStream {
+    let ident = item.ident.clone();
+    let name = LitByteStr::new(item.ident.to_string().as_bytes(), Span::call_site().into());
+
+    let expanded = quote! {
+        impl zink::Event for #ident {
+            const NAME: &'static [u8] = #name
+        }
+    };
+
+    expanded.into()
+}

--- a/zink/codegen/src/event.rs
+++ b/zink/codegen/src/event.rs
@@ -6,8 +6,8 @@ use syn::{DeriveInput, LitByteStr};
 
 /// Expand the event interface
 pub fn parse(item: DeriveInput) -> TokenStream {
-    let ident = item.ident.clone();
     let name = LitByteStr::new(item.ident.to_string().as_bytes(), Span::call_site().into());
+    let ident = item.ident;
 
     let expanded = quote! {
         impl zink::Event for #ident {

--- a/zink/codegen/src/event.rs
+++ b/zink/codegen/src/event.rs
@@ -11,7 +11,7 @@ pub fn parse(item: DeriveInput) -> TokenStream {
 
     let expanded = quote! {
         impl zink::Event for #ident {
-            const NAME: &'static [u8] = #name
+            const NAME: &'static [u8] = #name;
         }
     };
 

--- a/zink/codegen/src/lib.rs
+++ b/zink/codegen/src/lib.rs
@@ -1,0 +1,13 @@
+//! Code generation libary for the zink API
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+mod event;
+
+/// Event logging interface
+#[proc_macro_derive(Event)]
+pub fn event(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    event::parse(input)
+}

--- a/zink/codegen/src/lib.rs
+++ b/zink/codegen/src/lib.rs
@@ -1,4 +1,4 @@
-//! Code generation libary for the zink API
+//! Code generation library for the zink API
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/zink/codegen/src/lib.rs
+++ b/zink/codegen/src/lib.rs
@@ -6,6 +6,29 @@ use syn::{parse_macro_input, DeriveInput};
 mod event;
 
 /// Event logging interface
+///
+/// ```rust
+/// use zink::Event;
+///
+/// /// A `Ping` event.
+/// #[derive(Event)]
+/// struct Ping;
+///
+/// #[no_mangle]
+/// pub extern "C" fn log0() {
+///     Ping.log0();
+/// }
+/// ```
+///
+/// will generate:
+///
+/// ```rust
+/// struct Ping;
+///
+/// impl zink::Event for Ping {
+///     const NAME: &'static [u8] = b"Ping";
+/// }
+/// ```
 #[proc_macro_derive(Event)]
 pub fn event(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -6,6 +6,7 @@ mod event;
 pub mod ffi;
 
 pub use self::event::Event;
+pub use zink_codegen::Event;
 
 // Panic hook implementation
 #[cfg(not(test))]


### PR DESCRIPTION
Resolves #134 

### Changes

- [x] introduce package `zink-codegen`
- [x] re-export `Event` in `zink`
- [x] docs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
