### PR TITLE
chore(zink): move evm to the top level

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -74,14 +74,14 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "zink"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "zink-codegen",
 ]
 
 [[package]]
 name = "zink-codegen"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zink/codegen/src/storage.rs
+++ b/zink/codegen/src/storage.rs
@@ -39,13 +39,13 @@ pub fn parse(input: ItemType) -> TokenStream {
 
             fn get() -> #variable_type {
                 unsafe {
-                    zink::ffi::evm::sload(Self::STORAGE_KEY)
+                    zink::evm::sload(Self::STORAGE_KEY)
                 }
             }
 
             fn set(value: #variable_type) {
                 unsafe {
-                    zink::ffi::evm::sstore(Self::STORAGE_KEY, value);
+                    zink::evm::sstore(Self::STORAGE_KEY, value);
                 }
             }
         }

--- a/zink/src/event.rs
+++ b/zink/src/event.rs
@@ -1,6 +1,6 @@
 //! Event implementation
 
-use crate::ffi;
+use crate::evm;
 
 /// Zink event interface
 ///
@@ -10,25 +10,25 @@ pub trait Event {
 
     fn log0(&self) {
         unsafe {
-            ffi::evm::log0(Self::NAME);
+            evm::log0(Self::NAME);
         }
     }
 
     fn log1(&self, topic: &'static [u8]) {
         unsafe {
-            ffi::evm::log1(Self::NAME, topic);
+            evm::log1(Self::NAME, topic);
         }
     }
 
     fn log2(&self, topic1: &'static [u8], topic2: &'static [u8]) {
         unsafe {
-            ffi::evm::log2(Self::NAME, topic1, topic2);
+            evm::log2(Self::NAME, topic1, topic2);
         }
     }
 
     fn log3(&self, topic1: &'static [u8], topic2: &'static [u8], topic3: &'static [u8]) {
         unsafe {
-            ffi::evm::log3(Self::NAME, topic1, topic2, topic3);
+            evm::log3(Self::NAME, topic1, topic2, topic3);
         }
     }
 
@@ -40,7 +40,7 @@ pub trait Event {
         topic4: &'static [u8],
     ) {
         unsafe {
-            ffi::evm::log4(Self::NAME, topic1, topic2, topic3, topic4);
+            evm::log4(Self::NAME, topic1, topic2, topic3, topic4);
         }
     }
 }

--- a/zink/src/evm.rs
+++ b/zink/src/evm.rs
@@ -1,13 +1,9 @@
 //! EVM imports
 
 // EVM interfaces
-//
-// TODO: Align to 256-bit #20.
 #[link(wasm_import_module = "evm")]
 #[allow(improper_ctypes)]
 extern "C" {
-    // i32 -> 8 bytes
-
     /// Store a value in the storage
     pub fn sstore(key: i32, value: i32);
 
@@ -39,7 +35,4 @@ extern "C" {
         topic3: &'static [u8],
         topic4: &'static [u8],
     );
-
-    /// Copy code running in current environment to memory
-    pub fn codecopy(destOffset: u32, codeOffset: u32, size: u32);
 }

--- a/zink/src/ffi/mod.rs
+++ b/zink/src/ffi/mod.rs
@@ -1,7 +1,0 @@
-//! Zink bindings for compilation
-//!
-//! Host functions in this module will not
-//! being compiled to bytecode, but will be
-//! called by the compiler.
-
-pub mod evm;

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -3,7 +3,8 @@
 #![no_std]
 
 mod event;
-pub mod ffi;
+pub mod evm;
+mod primitive;
 mod storage;
 
 pub use self::{event::Event, storage::Storage};

--- a/zink/src/primitive/mod.rs
+++ b/zink/src/primitive/mod.rs
@@ -1,0 +1,3 @@
+//! Primitive types
+
+mod u256;

--- a/zink/src/primitive/u256.rs
+++ b/zink/src/primitive/u256.rs
@@ -1,0 +1,16 @@
+//! 256 bit unsigned integer
+
+/// 256 bit unsigned integer
+pub struct U256([u64; 4]);
+
+impl From<u64> for U256 {
+    fn from(val: u64) -> Self {
+        U256([val, 0, 0, 0])
+    }
+}
+
+impl From<u32> for U256 {
+    fn from(val: u32) -> Self {
+        U256([val as u64, 0, 0, 0])
+    }
+}


### PR DESCRIPTION
Resolves #20

### Changes

- [x] move `evm` to the top level of `zink`
- [x] introduce basic U256 type
- [ ] methods for creating `U256`
- [ ] arithmetic operations for `U256`


