### PR TITLE
refactor(zint): make ethers and wasm-opt optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,6 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
- "wasm-opt",
  "zinkc",
 ]
 
@@ -4778,6 +4777,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "wasm-opt",
  "wasmparser",
  "wat",
  "zabi",
@@ -4795,7 +4795,6 @@ dependencies = [
  "syn 2.0.41",
  "tracing",
  "tracing-subscriber",
- "wasm-opt",
  "wat",
  "zinkc",
 ]
@@ -4817,7 +4816,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wasm-opt",
  "zabi",
  "zinkc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,5 +100,5 @@ zink-codegen.workspace = true
 anyhow.workspace = true
 paste.workspace = true
 filetests.workspace = true
-zint.workspace = true
+zint = { workspace = true, features = [ "ethers" ] }
 tokio = { workspace = true, features = [ "macros" ] }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,8 @@
 ### Changes
 
 - Refactor conta with `toml_edit`
+- Optional ethers
+- Optional exports wasm-opt from zinkc
 
 ### FIXED
 

--- a/cli/elko/Cargo.toml
+++ b/cli/elko/Cargo.toml
@@ -20,5 +20,4 @@ serde = { workspace = true, features = [ "derive" ] }
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
-wasm-opt.workspace = true
-zinkc = { workspace = true, features = [ "cli" ] }
+zinkc = { workspace = true, features = [ "cli", "utils" ] }

--- a/cli/elko/Cargo.toml
+++ b/cli/elko/Cargo.toml
@@ -23,4 +23,5 @@ tracing.workspace = true
 zinkc = { workspace = true, features = [ "cli", "utils" ] }
 
 [features]
+default = [ "wasm-opt" ]
 wasm-opt = [ "zinkc/wasm-opt" ]

--- a/cli/elko/Cargo.toml
+++ b/cli/elko/Cargo.toml
@@ -20,8 +20,4 @@ serde = { workspace = true, features = [ "derive" ] }
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
-zinkc = { workspace = true, features = [ "cli", "utils" ] }
-
-[features]
-default = [ "wasm-opt" ]
-wasm-opt = [ "zinkc/wasm-opt" ]
+zinkc = { workspace = true, features = [ "cli" ] }

--- a/cli/elko/Cargo.toml
+++ b/cli/elko/Cargo.toml
@@ -21,3 +21,6 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 zinkc = { workspace = true, features = [ "cli", "utils" ] }
+
+[features]
+wasm-opt = [ "zinkc/wasm-opt" ]

--- a/cli/elko/src/utils/result.rs
+++ b/cli/elko/src/utils/result.rs
@@ -15,9 +15,6 @@ pub enum Error {
     /// IO error
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    /// Serde JSON error
-    #[error(transparent)]
-    WasmOpt(#[from] wasm_opt::OptimizationError),
 }
 
 /// Zinkc result

--- a/cli/elko/src/utils/wasm.rs
+++ b/cli/elko/src/utils/wasm.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use cargo_metadata::{Metadata, MetadataCommand, Package};
 use etc::{Etc, FileSystem};
 use std::{fs, path::PathBuf, process::Command};
-use wasm_opt::OptimizationOptions;
 
 /// WASM Builder
 pub struct WasmBuilder {
@@ -120,11 +119,7 @@ impl WasmBuilder {
             .with_extension("wasm");
 
         // run the wasm optimizer
-        OptimizationOptions::new_opt_level_4()
-            .debug_info(false)
-            .mvp_features_only()
-            .set_converge()
-            .run(src, self.output()?)?;
+        zinkc::utils::wasm_opt(src, self.output()?)?;
 
         Ok(())
     }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -35,5 +35,5 @@ zabi.workspace = true
 etc.workspace = true
 
 [features]
-cli = [ "ccli", "serde_json", "utils" ]
+cli = [ "ccli", "serde_json" ]
 utils = [ ]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -20,8 +20,11 @@ tracing.workspace = true
 wasmparser.workspace = true
 zabi.workspace = true
 zingen.workspace = true
+
+# Optional dependencies
 ccli = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+wasm-opt = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true
@@ -32,4 +35,5 @@ zabi.workspace = true
 etc.workspace = true
 
 [features]
-cli = [ "ccli", "serde_json" ]
+cli = [ "ccli", "serde_json", "utils" ]
+utils = [ ]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -35,5 +35,5 @@ zabi.workspace = true
 etc.workspace = true
 
 [features]
-cli = [ "ccli", "serde_json" ]
-utils = [ ]
+cli = [ "ccli", "serde_json", "utils" ]
+utils = [ "wasm-opt" ]

--- a/compiler/filetests/Cargo.toml
+++ b/compiler/filetests/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 wat.workspace = true
-wasm-opt.workspace = true
+zinkc = { workspace = true, features = [ "utils" ] }
 
 [features]
 testing = []

--- a/compiler/filetests/Cargo.toml
+++ b/compiler/filetests/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 wat.workspace = true
-zinkc = { workspace = true, features = [ "utils" ] }
+zinkc = { workspace = true, features = [ "utils", "wasm-opt" ] }
 
 [features]
 testing = []

--- a/compiler/filetests/build.rs
+++ b/compiler/filetests/build.rs
@@ -9,7 +9,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use syn::{parse_quote, ExprArray, ExprMatch, Ident, ItemImpl, ItemMod};
-use wasm_opt::OptimizationOptions;
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
@@ -97,11 +96,7 @@ fn examples() -> Result<Vec<PathBuf>> {
         .collect::<Vec<_>>();
 
     for wasm in &files {
-        OptimizationOptions::new_opt_level_4()
-            .debug_info(false)
-            .mvp_features_only()
-            .set_converge()
-            .run(wasm, wasm)?;
+        zinkc::utils::wasm_opt(wasm, wasm)?;
     }
 
     Ok(files)

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -12,3 +12,4 @@ mod compiler;
 mod config;
 mod parser;
 mod result;
+pub mod utils;

--- a/compiler/src/utils.rs
+++ b/compiler/src/utils.rs
@@ -1,0 +1,50 @@
+//! Zink compiler utils
+#![cfg(feature = "utils")]
+
+use std::path::Path;
+
+#[cfg(feature = "wasm-opt")]
+/// Run wasm-opt on the given WASM file.
+pub fn wasm_opt(input: impl AsRef<Path>, output: impl AsRef<Path>) -> anyhow::Result<()> {
+    ::wasm_opt::OptimizationOptions::new_opt_level_4()
+        .shrink_level(::wasm_opt::ShrinkLevel::Level2)
+        .debug_info(false)
+        .mvp_features_only()
+        .set_converge()
+        .run(&input, &output)
+        .map_err(Into::into)
+}
+
+#[cfg(not(feature = "wasm-opt"))]
+/// Run wasm-opt on the given WASM file.
+pub fn wasm_opt(wasm: impl AsRef<Path>, output: impl AsRef<Path>) -> anyhow::Result<()> {
+    use std::process::{Command, Stdio};
+
+    let [input, output] = [
+        wasm.as_ref().to_string_lossy(),
+        output.as_ref().to_string_lossy(),
+    ];
+    let output = Command::new("wasm-opt")
+        .args([
+            input.as_ref(),
+            "--mvp-features",
+            "-O4",
+            "-s",
+            "2",
+            "--converge",
+            "-o",
+            output.as_ref(),
+        ])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .output()?;
+
+    if !output.stderr.is_empty() {
+        return Err(anyhow::anyhow!(
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}

--- a/compiler/src/utils.rs
+++ b/compiler/src/utils.rs
@@ -3,7 +3,6 @@
 
 use std::path::Path;
 
-#[cfg(feature = "wasm-opt")]
 /// Run wasm-opt on the given WASM file.
 pub fn wasm_opt(input: impl AsRef<Path>, output: impl AsRef<Path>) -> anyhow::Result<()> {
     ::wasm_opt::OptimizationOptions::new_opt_level_4()
@@ -13,38 +12,4 @@ pub fn wasm_opt(input: impl AsRef<Path>, output: impl AsRef<Path>) -> anyhow::Re
         .set_converge()
         .run(&input, &output)
         .map_err(Into::into)
-}
-
-#[cfg(not(feature = "wasm-opt"))]
-/// Run wasm-opt on the given WASM file.
-pub fn wasm_opt(wasm: impl AsRef<Path>, output: impl AsRef<Path>) -> anyhow::Result<()> {
-    use std::process::{Command, Stdio};
-
-    let [input, output] = [
-        wasm.as_ref().to_string_lossy(),
-        output.as_ref().to_string_lossy(),
-    ];
-    let output = Command::new("wasm-opt")
-        .args([
-            input.as_ref(),
-            "--mvp-features",
-            "-O4",
-            "-s",
-            "2",
-            "--converge",
-            "-o",
-            output.as_ref(),
-        ])
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .output()?;
-
-    if !output.stderr.is_empty() {
-        return Err(anyhow::anyhow!(
-            "{}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-
-    Ok(())
 }

--- a/zint/Cargo.toml
+++ b/zint/Cargo.toml
@@ -27,4 +27,5 @@ zabi.workspace = true
 zinkc =  { workspace = true, features = [ "utils" ] }
 
 [features]
+default = [ "wasm-opt" ]
 wasm-opt = [ "zinkc/wasm-opt" ]

--- a/zint/Cargo.toml
+++ b/zint/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 anyhow.workspace = true
 cargo_metadata.workspace = true
 etc.workspace = true
-ethers.workspace = true
+ethers = { workspace = true, optional = true }
 hex.workspace = true
 revm.workspace = true
 serde = { workspace = true, features = [ "derive" ] }

--- a/zint/Cargo.toml
+++ b/zint/Cargo.toml
@@ -23,6 +23,5 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"]}
 toml.workspace = true
 url.workspace = true
-wasm-opt.workspace = true
 zabi.workspace = true
-zinkc.workspace = true
+zinkc =  { workspace = true, features = [ "utils" ] }

--- a/zint/Cargo.toml
+++ b/zint/Cargo.toml
@@ -25,3 +25,6 @@ toml.workspace = true
 url.workspace = true
 zabi.workspace = true
 zinkc =  { workspace = true, features = [ "utils" ] }
+
+[features]
+wasm-opt = [ "zinkc/wasm-opt" ]

--- a/zint/Cargo.toml
+++ b/zint/Cargo.toml
@@ -25,7 +25,3 @@ toml.workspace = true
 url.workspace = true
 zabi.workspace = true
 zinkc =  { workspace = true, features = [ "utils" ] }
-
-[features]
-default = [ "wasm-opt" ]
-wasm-opt = [ "zinkc/wasm-opt" ]

--- a/zint/src/api.rs
+++ b/zint/src/api.rs
@@ -1,6 +1,8 @@
-//! Zink SDK.
+//! Zink ethers integration.
+#![cfg(feature = "ethers")]
 
 use crate::Result;
+pub use ethers;
 use ethers::{
     abi::Abi,
     contract::ContractFactory,

--- a/zint/src/contract.rs
+++ b/zint/src/contract.rs
@@ -3,11 +3,7 @@
 use crate::{Bytes32, Info, EVM};
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-use wasm_opt::OptimizationOptions;
+use std::{fs, path::PathBuf};
 use zabi::Abi;
 use zinkc::Compiler;
 
@@ -53,16 +49,6 @@ impl Contract {
                     .join("wasm32-unknown-unknown")
                     .into()
             })
-    }
-
-    /// Run wasm-opt on the given WASM file.
-    fn wasm_opt(wasm: impl AsRef<Path>) -> Result<()> {
-        OptimizationOptions::new_opt_level_4()
-            .debug_info(false)
-            .mvp_features_only()
-            .set_converge()
-            .run(&wasm, &wasm)
-            .map_err(Into::into)
     }
 
     /// Create new contract
@@ -140,7 +126,7 @@ impl Contract {
         };
 
         let wasm = search("release").or_else(|_| search("debug"))?;
-        Self::wasm_opt(&wasm)?;
+        zinkc::utils::wasm_opt(&wasm, &wasm)?;
 
         tracing::debug!("loading contract from {}", wasm.display());
         Ok(Self::new(fs::read(wasm)?))

--- a/zint/src/evm.rs
+++ b/zint/src/evm.rs
@@ -80,8 +80,8 @@ impl EVM {
     pub fn run(btyecode: &[u8], input: &[u8]) -> Info {
         let mut evm = Self::new(btyecode, input);
         let info = evm.execute();
-        tracing::debug!("{info:?}");
 
+        tracing::debug!("{info:?}");
         info
     }
 }

--- a/zint/src/lib.rs
+++ b/zint/src/lib.rs
@@ -8,14 +8,15 @@ mod evm;
 mod result;
 
 pub use self::{
-    api::Ethers,
     bytes::Bytes32,
     contract::Contract,
     evm::{Info, InstructionResult, EVM, U256},
     result::Result,
 };
-pub use ethers;
 use tracing_subscriber::EnvFilter;
+
+#[cfg(feature = "ethers")]
+pub use api::*;
 
 /// Set up the logger.
 pub fn setup_logger() {

--- a/zint/src/result.rs
+++ b/zint/src/result.rs
@@ -1,22 +1,23 @@
 //! Zink sdk results.
 
-use crate::api::Signer;
-
 /// Zint error.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[cfg(feature = "ethers")]
     /// Ethers abi error.
     #[error(transparent)]
     Abi(#[from] ethers::abi::AbiError),
     /// Anyhow error.
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
+    #[cfg(feature = "ethers")]
     /// Ethers contract error.
     #[error(transparent)]
-    Contract(#[from] ethers::middleware::contract::ContractError<Signer>),
+    Contract(#[from] ethers::middleware::contract::ContractError<crate::api::Signer>),
     /// Url parser error.
     #[error(transparent)]
     Url(#[from] url::ParseError),
+    #[cfg(feature = "ethers")]
     /// Ethers wallet error.
     #[error(transparent)]
     Wallet(#[from] ethers::signers::WalletError),


### PR DESCRIPTION
Resolves #182 
Resolves #181 

### Changes

- [x] make ethers optional
- [x] make wasm-opt optional
- [x] embed wasm-opt in `zinkc`

---

still can not get rid of `wasm-opt`, make it optional 
