### PR TITLE
feat(zink): auto generate storage keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "evm-opcodes",
  "hex",
  "paste",
+ "tiny-keccak",
  "tracing",
  "zink-codegen",
  "zinkc-filetests",
@@ -2643,7 +2644,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
- "tiny-keccak",
  "zabi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,9 +2639,11 @@ name = "zink-codegen"
 version = "0.1.11"
 dependencies = [
  "heck 0.5.0",
+ "hex",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+ "tiny-keccak",
  "zabi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ path = "zink/src/lib.rs"
 paste.workspace = true
 zink-codegen.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tiny-keccak.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 anyhow.workspace = true
 filetests.workspace = true

--- a/abi/src/abi.rs
+++ b/abi/src/abi.rs
@@ -1,0 +1,77 @@
+//! Zink ABI implementation
+//!
+//! Currently just a wrapper of solidity ABI.
+
+use core::ops::{Deref, DerefMut};
+
+/// Function ABI.
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Abi(sol_abi::Abi);
+
+impl Deref for Abi {
+    type Target = sol_abi::Abi;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Abi {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Abi {
+    /// Convert [`Abi`] to bytes.
+    pub fn to_bytes(&self) -> postcard::Result<Vec<u8>> {
+        postcard::to_stdvec(self).map_err(Into::into)
+    }
+
+    /// Convert bytes to [`Abi`].
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> postcard::Result<Self> {
+        postcard::from_bytes(bytes.as_ref()).map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "hex")]
+mod hex_impl {
+    use crate::{result::Result, Abi};
+    use core::fmt;
+
+    impl Abi {
+        /// Convert [`Abi`] to hex string.
+        pub fn to_hex(&self) -> Result<String> {
+            Ok("0x".to_string() + &hex::encode(self.to_bytes()?))
+        }
+
+        /// Convert hex string to [`Abi`].
+        pub fn from_hex(hex: impl AsRef<str>) -> Result<Self> {
+            Self::from_bytes(hex::decode(hex.as_ref().trim_start_matches("0x"))?)
+                .map_err(Into::into)
+        }
+    }
+
+    impl fmt::Display for Abi {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self.to_hex().unwrap_or_default())
+        }
+    }
+
+    impl core::str::FromStr for Abi {
+        type Err = crate::result::Error;
+
+        fn from_str(hex: &str) -> Result<Self> {
+            Self::from_hex(hex)
+        }
+    }
+}
+
+#[cfg(feature = "syn")]
+impl From<&syn::Signature> for Abi {
+    fn from(sig: &syn::Signature) -> Self {
+        Self(sol_abi::Abi::from(sig))
+    }
+}

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -2,79 +2,11 @@
 //!
 //! Currently just a wrapper of solidity ABI.
 
+mod abi;
 pub mod result;
 pub mod selector;
 
-use core::ops::{Deref, DerefMut};
+pub use abi::Abi;
 
-/// Function ABI.
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Abi(sol_abi::Abi);
-
-impl Deref for Abi {
-    type Target = sol_abi::Abi;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Abi {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-#[cfg(feature = "bytes")]
-impl Abi {
-    /// Convert [`Abi`] to bytes.
-    pub fn to_bytes(&self) -> postcard::Result<Vec<u8>> {
-        postcard::to_stdvec(self).map_err(Into::into)
-    }
-
-    /// Convert bytes to [`Abi`].
-    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> postcard::Result<Self> {
-        postcard::from_bytes(bytes.as_ref()).map_err(Into::into)
-    }
-}
-
-#[cfg(feature = "hex")]
-mod hex_impl {
-    use crate::{result::Result, Abi};
-    use core::fmt;
-
-    impl Abi {
-        /// Convert [`Abi`] to hex string.
-        pub fn to_hex(&self) -> Result<String> {
-            Ok("0x".to_string() + &hex::encode(self.to_bytes()?))
-        }
-
-        /// Convert hex string to [`Abi`].
-        pub fn from_hex(hex: impl AsRef<str>) -> Result<Self> {
-            Self::from_bytes(hex::decode(hex.as_ref().trim_start_matches("0x"))?)
-                .map_err(Into::into)
-        }
-    }
-
-    impl fmt::Display for Abi {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "{}", self.to_hex().unwrap_or_default())
-        }
-    }
-
-    impl core::str::FromStr for Abi {
-        type Err = crate::result::Error;
-
-        fn from_str(hex: &str) -> Result<Self> {
-            Self::from_hex(hex)
-        }
-    }
-}
-
-#[cfg(feature = "syn")]
-impl From<&syn::Signature> for Abi {
-    fn from(sig: &syn::Signature) -> Self {
-        Self(sol_abi::Abi::from(sig))
-    }
-}
+#[cfg(feature = "selector")]
+pub use selector::keccak256;

--- a/examples/dkmapping.rs
+++ b/examples/dkmapping.rs
@@ -41,7 +41,8 @@ fn storage_double_key_mapping() -> anyhow::Result<()> {
     assert!(info.ret.is_empty());
 
     // verify result with database
-    let storage_key = zint::keccak256(&[[0; 32], [0; 32], 1.to_bytes32()].concat());
+    let _sk = zint::keccak256(&[[0; 32], [0; 32], 1.to_bytes32()].concat());
+    let storage_key = DoubleKeyMapping::storage_key(key1, key2);
     assert_eq!(
         evm.storage(contract.address, storage_key)?,
         value.to_bytes32(),

--- a/examples/mapping.rs
+++ b/examples/mapping.rs
@@ -39,7 +39,7 @@ fn storage_mapping() -> anyhow::Result<()> {
     assert!(info.ret.is_empty());
 
     // verify result with database
-    let storage_key = zint::keccak256(&[0; 0x40]);
+    let storage_key = Mapping::storage_key(key);
     assert_eq!(
         evm.storage(contract.address, storage_key)?,
         value.to_bytes32(),

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -26,11 +26,13 @@ fn value() -> anyhow::Result<()> {
     let mut contract = Contract::search("storage")?.compile()?;
 
     {
-        let key = 0;
         let value: i32 = 42;
         let info = contract.execute(&[b"set(int32)".to_vec(), value.to_bytes32().to_vec()])?;
         assert!(info.ret.is_empty());
-        assert_eq!(info.storage.get(&U256::from(key)), Some(&U256::from(value)));
+        assert_eq!(
+            info.storage.get(&U256::from_le_bytes(Counter::KEY)),
+            Some(&U256::from(value))
+        );
     }
 
     {

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -30,7 +30,7 @@ fn value() -> anyhow::Result<()> {
         let info = contract.execute(&[b"set(int32)".to_vec(), value.to_bytes32().to_vec()])?;
         assert!(info.ret.is_empty());
         assert_eq!(
-            info.storage.get(&U256::from_le_bytes(Counter::KEY)),
+            info.storage.get(&U256::from_le_bytes(Counter::STORAGE_KEY)),
             Some(&U256::from(value))
         );
     }

--- a/zink/codegen/Cargo.toml
+++ b/zink/codegen/Cargo.toml
@@ -14,7 +14,9 @@ proc-macro = true
 
 [dependencies]
 heck.workspace = true
+hex.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+tiny-keccak.workspace = true
 zabi = { workspace = true, features = [ "hex", "syn" ] }

--- a/zink/codegen/Cargo.toml
+++ b/zink/codegen/Cargo.toml
@@ -18,5 +18,4 @@ hex.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-tiny-keccak.workspace = true
 zabi = { workspace = true, features = [ "hex", "syn" ] }

--- a/zink/src/asm.rs
+++ b/zink/src/asm.rs
@@ -7,6 +7,9 @@ use paste::paste;
 pub trait Asm: Copy {
     /// Push self on the stack.
     fn push(self);
+
+    #[cfg(not(target_family = "wasm"))]
+    fn bytes32(&self) -> [u8; 32];
 }
 
 macro_rules! impl_asm {
@@ -16,6 +19,14 @@ macro_rules! impl_asm {
                 unsafe {
                     paste! { ffi::asm::[<push_ $ty>](self); }
                 }
+            }
+
+            #[cfg(not(target_family = "wasm"))]
+            fn bytes32(&self) -> [u8; 32] {
+                let mut output = [0; 32];
+                let bytes = self.to_le_bytes();
+                output[(32 - bytes.len())..].copy_from_slice(&bytes);
+                output
             }
         }
     };

--- a/zink/src/asm.rs
+++ b/zink/src/asm.rs
@@ -23,10 +23,7 @@ macro_rules! impl_asm {
 
             #[cfg(not(target_family = "wasm"))]
             fn bytes32(&self) -> [u8; 32] {
-                let mut output = [0; 32];
-                let bytes = self.to_le_bytes();
-                output[(32 - bytes.len())..].copy_from_slice(&bytes);
-                output
+                crate::to_bytes32(&self.to_le_bytes())
             }
         }
     };

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -12,6 +12,17 @@ pub use self::{asm::Asm, event::Event};
 pub use storage::{DoubleKeyMapping, Mapping, Storage};
 pub use zink_codegen::{external, storage, Event};
 
+/// Generate a keccak hash of the input (sha3)
+#[cfg(not(target_family = "wasm"))]
+pub fn keccak256(input: &[u8]) -> [u8; 32] {
+    use tiny_keccak::{Hasher, Keccak};
+    let mut hasher = Keccak::v256();
+    let mut output = [0; 32];
+    hasher.update(input);
+    hasher.finalize(&mut output);
+    output
+}
+
 // Panic hook implementation
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -2,6 +2,9 @@
 
 #![no_std]
 
+#[cfg(not(target_family = "wasm"))]
+extern crate alloc;
+
 mod asm;
 mod event;
 pub mod ffi;
@@ -21,6 +24,26 @@ pub fn keccak256(input: &[u8]) -> [u8; 32] {
     hasher.update(input);
     hasher.finalize(&mut output);
     output
+}
+
+/// Convert bytes to ls bytes
+#[cfg(not(target_family = "wasm"))]
+pub fn to_bytes32(src: &[u8]) -> [u8; 32] {
+    use alloc::vec::Vec;
+    let mut bytes = [0u8; 32];
+    let ls_bytes = {
+        src.iter()
+            .cloned()
+            .rev()
+            .skip_while(|b| *b == 0)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+    };
+
+    bytes[(32 - ls_bytes.len())..].copy_from_slice(&ls_bytes);
+    bytes
 }
 
 // Panic hook implementation

--- a/zink/src/primitives/address.rs
+++ b/zink/src/primitives/address.rs
@@ -3,7 +3,10 @@ use crate::{ffi, storage::StorageValue, Asm};
 /// Account address
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct Address(i32);
+pub struct Address(
+    #[cfg(target_family = "wasm")] i32,
+    #[cfg(not(target_family = "wasm"))] [u8; 20],
+);
 
 impl Address {
     /// if self equal to another
@@ -18,6 +21,13 @@ impl Address {
 impl Asm for Address {
     fn push(self) {
         unsafe { ffi::asm::push_address(self) }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn bytes32(&self) -> [u8; 32] {
+        let mut output = [0; 32];
+        output[12..].copy_from_slice(&self.0);
+        output
     }
 }
 

--- a/zink/src/storage/dkmapping.rs
+++ b/zink/src/storage/dkmapping.rs
@@ -10,6 +10,9 @@ pub trait DoubleKeyMapping {
     type Key2: Asm;
     type Value: StorageValue;
 
+    #[cfg(not(target_family = "wasm"))]
+    fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32];
+
     /// Get value from storage key.
     fn get(key1: Self::Key1, key2: Self::Key2) -> Self::Value {
         load_double_key(key1, key2, Self::STORAGE_SLOT);

--- a/zink/src/storage/mapping.rs
+++ b/zink/src/storage/mapping.rs
@@ -9,6 +9,9 @@ pub trait Mapping {
     type Key: Asm;
     type Value: StorageValue;
 
+    #[cfg(not(target_family = "wasm"))]
+    fn storage_key(key: Self::Key) -> [u8; 32];
+
     /// Get value from storage key.
     fn get(key: Self::Key) -> Self::Value {
         load_key(key, Self::STORAGE_SLOT);

--- a/zink/src/storage/value.rs
+++ b/zink/src/storage/value.rs
@@ -3,7 +3,10 @@ use crate::{ffi, storage::StorageValue, Asm};
 
 /// Storage trait. Currently not for public use
 pub trait Storage {
+    #[cfg(not(target_family = "wasm"))]
+    const KEY: [u8; 32];
     const STORAGE_SLOT: i32;
+
     type Value: StorageValue + Asm;
 
     /// Get value from storage.

--- a/zink/src/storage/value.rs
+++ b/zink/src/storage/value.rs
@@ -4,7 +4,7 @@ use crate::{ffi, storage::StorageValue, Asm};
 /// Storage trait. Currently not for public use
 pub trait Storage {
     #[cfg(not(target_family = "wasm"))]
-    const KEY: [u8; 32];
+    const STORAGE_KEY: [u8; 32];
     const STORAGE_SLOT: i32;
 
     type Value: StorageValue + Asm;


### PR DESCRIPTION
Resolves #

Storage structs now have functions for generating keys in non-wasm environments

### Changes

- [x] generate keys for storage values
- [x] generate keys for storage mapping
- [x] generate keys for storage double mappings
