### PR TITLE
refactor(storage): reorder hash key components 

### DIFF
--- a/codegen/src/visitor/local.rs
+++ b/codegen/src/visitor/local.rs
@@ -76,7 +76,9 @@ impl Function {
         tracing::trace!("local_get: {local_index} {local_sp} {sp}");
 
         // TODO: Arthmetic checks
-        self.masm.dup(sp - local_sp)?;
+        if sp > local_sp + 1 {
+            self.masm.dup(sp - local_sp)?;
+        }
         Ok(())
     }
 }

--- a/compiler/filetests/lib.rs
+++ b/compiler/filetests/lib.rs
@@ -28,7 +28,12 @@ impl Test {
         let Test { module, name, wasm } = self;
         tracing::info!("Compiling {module}::{name}");
 
-        zinkc::Compiler::default().compile(&wasm)?;
+        let mut compiler = zinkc::Compiler::default();
+        // TODO: after #166
+        if name == "fibonacci" {
+            compiler.config = compiler.config.dispatcher(true);
+        }
+        compiler.compile(&wasm)?;
         Ok(())
     }
 }

--- a/examples/dkmapping.rs
+++ b/examples/dkmapping.rs
@@ -33,16 +33,16 @@ fn storage_double_key_mapping() -> anyhow::Result<()> {
     // set value to storage
     let calldata = contract.encode(&[
         b"mset(int32,int32,int32)".to_vec(),
-        value.to_bytes32().to_vec(),
-        key2.to_bytes32().to_vec(),
         key1.to_bytes32().to_vec(),
+        key2.to_bytes32().to_vec(),
+        value.to_bytes32().to_vec(),
     ])?;
     let info = evm.calldata(&calldata).call(contract.address)?;
     assert!(info.ret.is_empty());
 
     // verify result with database
-    let _sk = zint::keccak256(&[[0; 32], [0; 32], 1.to_bytes32()].concat());
     let storage_key = DoubleKeyMapping::storage_key(key1, key2);
+    tracing::info!("Storag key: {}", hex::encode(storage_key));
     assert_eq!(
         evm.storage(contract.address, storage_key)?,
         value.to_bytes32(),
@@ -51,8 +51,8 @@ fn storage_double_key_mapping() -> anyhow::Result<()> {
     // get value from storage
     let calldata = contract.encode(&[
         b"double_key_mapping(int32,int32)".to_vec(),
-        key2.to_bytes32().to_vec(),
         key1.to_bytes32().to_vec(),
+        key2.to_bytes32().to_vec(),
     ])?;
     let info = evm.calldata(&calldata).call(contract.address)?;
     assert_eq!(info.ret, value.to_bytes32(), "{info:#?}",);

--- a/examples/dkmapping.rs
+++ b/examples/dkmapping.rs
@@ -42,7 +42,7 @@ fn storage_double_key_mapping() -> anyhow::Result<()> {
 
     // verify result with database
     let storage_key = DoubleKeyMapping::storage_key(key1, key2);
-    tracing::info!("Storag key: {}", hex::encode(storage_key));
+    tracing::info!("Storage key: {}", hex::encode(storage_key));
     assert_eq!(
         evm.storage(contract.address, storage_key)?,
         value.to_bytes32(),

--- a/examples/mapping.rs
+++ b/examples/mapping.rs
@@ -32,8 +32,8 @@ fn storage_mapping() -> anyhow::Result<()> {
     // set value to storage
     let calldata = contract.encode(&[
         b"mset(int32,int32)".to_vec(),
-        value.to_bytes32().to_vec(),
         key.to_bytes32().to_vec(),
+        value.to_bytes32().to_vec(),
     ])?;
     let info = evm.calldata(&calldata).call(contract.address)?;
     assert!(info.ret.is_empty());

--- a/zink/codegen/src/storage.rs
+++ b/zink/codegen/src/storage.rs
@@ -138,10 +138,12 @@ impl Storage {
                 fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32] {
                     use zink::Asm;
 
-                    let mut seed = [0; 96];
-                    seed[29..=32].copy_from_slice(&Self::STORAGE_SLOT.to_le_bytes());
-                    seed[33..=64].copy_from_slice(&key1.bytes32());
-                    seed[64..].copy_from_slice(&key2.bytes32());
+                    let mut seed = [0; 64];
+                    seed[..32].copy_from_slice(&key1.bytes32());
+                    seed[60..].copy_from_slice(&Self::STORAGE_SLOT.to_le_bytes());
+                    let skey1 = zink::keccak256(&seed);
+                    seed[..32].copy_from_slice(&skey1);
+                    seed[32..].copy_from_slice(&key2.bytes32());
                     zink::keccak256(&seed)
                 }
             }

--- a/zink/codegen/src/storage.rs
+++ b/zink/codegen/src/storage.rs
@@ -82,10 +82,7 @@ impl Storage {
         let is = &self.target;
         let name = self.target.ident.clone();
         let slot = storage_slot(name.to_string());
-        let mut seed = [0; 64];
-        seed[29..=32].copy_from_slice(&slot.to_le_bytes());
 
-        let seedl = Literal::byte_string(&seed);
         let mut expanded = quote! {
             #is
 
@@ -99,8 +96,9 @@ impl Storage {
                 fn storage_key(key: Self::Key) -> [u8; 32] {
                     use zink::Asm;
 
-                    let mut seed = *#seedl;
-                    seed[32..].copy_from_slice(&key.bytes32());
+                    let mut seed = [0; 64];
+                    seed[..32].copy_from_slice(&key.bytes32());
+                    seed[60..].copy_from_slice(&Self::STORAGE_SLOT.to_le_bytes());
                     zink::keccak256(&seed)
                 }
             }
@@ -125,10 +123,7 @@ impl Storage {
         let is = &self.target;
         let name = self.target.ident.clone();
         let slot = storage_slot(name.to_string());
-        let mut seed = [0; 96];
-        seed[29..=32].copy_from_slice(&slot.to_le_bytes());
 
-        let seedl = Literal::byte_string(&seed);
         let mut expanded = quote! {
             #is
 
@@ -143,7 +138,8 @@ impl Storage {
                 fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32] {
                     use zink::Asm;
 
-                    let mut seed = *#seedl;
+                    let mut seed = [0; 96];
+                    seed[29..=32].copy_from_slice(&Self::STORAGE_SLOT.to_le_bytes());
                     seed[33..=64].copy_from_slice(&key1.bytes32());
                     seed[64..].copy_from_slice(&key2.bytes32());
                     zink::keccak256(&seed)

--- a/zink/src/storage/dkmapping.rs
+++ b/zink/src/storage/dkmapping.rs
@@ -35,12 +35,17 @@ fn load_double_key(key1: impl Asm, key2: impl Asm, index: i32) {
         // write index to memory
         index.push();
         ffi::evm::push0();
-        ffi::evm::mstore8();
+        ffi::evm::mstore();
 
         // write key to memory
         key1.push();
         ffi::asm::push_u8(0x20);
         ffi::evm::mstore();
+
+        // TODO:
+        //
+        // a. do the hashing first time
+        // b. store the result on stack
 
         // write key to memory
         key2.push();

--- a/zink/src/storage/dkmapping.rs
+++ b/zink/src/storage/dkmapping.rs
@@ -30,30 +30,35 @@ pub trait DoubleKeyMapping {
 }
 
 /// Load storage key to stack
+#[inline(always)]
 fn load_double_key(key1: impl Asm, key2: impl Asm, index: i32) {
     unsafe {
-        // write index to memory
-        index.push();
+        // write key1 to memory
+        key1.push();
         ffi::evm::push0();
         ffi::evm::mstore();
 
-        // write key to memory
-        key1.push();
+        // write index to memory
+        index.push();
         ffi::asm::push_u8(0x20);
         ffi::evm::mstore();
 
-        // TODO:
-        //
-        // a. do the hashing first time
-        // b. store the result on stack
-
-        // write key to memory
-        key2.push();
+        // hash key
         ffi::asm::push_u8(0x40);
+        ffi::evm::push0();
+        ffi::evm::keccak256();
+
+        // stores the hash
+        ffi::evm::push0();
+        ffi::evm::mstore();
+
+        // write index to memory
+        key2.push();
+        ffi::asm::push_u8(0x20);
         ffi::evm::mstore();
 
         // hash key
-        ffi::asm::push_u8(0x60);
+        ffi::asm::push_u8(0x40);
         ffi::evm::push0();
         ffi::evm::keccak256();
     }

--- a/zink/src/storage/mapping.rs
+++ b/zink/src/storage/mapping.rs
@@ -31,13 +31,13 @@ pub trait Mapping {
 /// Load storage key to stack
 fn load_key(key: impl Asm, index: i32) {
     unsafe {
-        // write index to memory
-        index.push();
-        ffi::evm::push0();
-        ffi::evm::mstore8();
-
         // write key to memory
         key.push();
+        ffi::evm::push0();
+        ffi::evm::mstore();
+
+        // write index to memory
+        index.push();
         ffi::asm::push_u8(0x20);
         ffi::evm::mstore();
 


### PR DESCRIPTION
Resolves #242 
ref #166

1. The same storage declaration will be able to call the storage interfaces of solidity contracts, this is for writing zink as tests of solidity contracts
2. reserve first 64 bytes instead of 96 bytes, however  whatever `96` or `64` bytes could be a dynamic solution in the future, if the contract only has storage value, the reserved memory should be `32`, if the contract has no storage, reserved memory should be zero, etc.

### Changes

- [x] re-order hash key components of mappings
- [x] re-order hash key components of double key mappings

