### PR TITLE
refactor(codegen): get locals from calldata directly in external functions

### DIFF
--- a/codegen/src/local.rs
+++ b/codegen/src/local.rs
@@ -87,10 +87,11 @@ impl Locals {
         let offset = if local.ty() == &LocalSlotType::Parameter {
             self.inner[..index].iter().fold(0, |acc, x| acc + x.align())
         } else {
-            self.inner[..index]
-                .iter()
-                .filter(|x| x.ty() == &LocalSlotType::Variable)
-                .fold(0, |acc, x| acc + x.align())
+            panic!("This should never be reached");
+            // self.inner[..index]
+            //     .iter()
+            //     .filter(|x| x.ty() == &LocalSlotType::Variable)
+            //     .fold(0, |acc, x| acc + x.align())
         }
         .to_ls_bytes()
         .to_vec()

--- a/codegen/src/visitor/call.rs
+++ b/codegen/src/visitor/call.rs
@@ -17,6 +17,11 @@ impl Function {
 
     /// The call instruction calls a function specified by its index.
     pub fn _call(&mut self, index: u32) -> Result<()> {
+        if self.env.is_external(index) {
+            // TODO: throw with error
+            panic!("External functions could not be called internally");
+        }
+
         if self.env.imports.len() as u32 > index {
             self.call_imported(index)
         } else {

--- a/codegen/src/visitor/control.rs
+++ b/codegen/src/visitor/control.rs
@@ -138,12 +138,12 @@ impl Function {
     pub fn _end(&mut self) -> Result<()> {
         if let Ok(frame) = self.control.pop() {
             self.handle_frame_popping(frame)
-        } else if !self.is_main {
-            tracing::trace!("end of call");
-            self.handle_call_return()
-        } else {
+        } else if self.is_main || self.abi.is_some() {
             tracing::trace!("end of main function");
             self.handle_return()
+        } else {
+            tracing::trace!("end of call");
+            self.handle_call_return()
         }
     }
 

--- a/codegen/src/visitor/local.rs
+++ b/codegen/src/visitor/local.rs
@@ -1,12 +1,12 @@
 //! Local instructions
 
-use crate::{Error, Function, Result};
+use crate::{wasm::ToLSBytes, Error, Function, Result};
 
 impl Function {
     /// This instruction gets the value of a variable.
     pub fn _local_get(&mut self, local_index: u32) -> Result<()> {
         let local_index = local_index as usize;
-        if self.is_main && local_index < self.ty.params().len() {
+        if (self.is_main && local_index < self.ty.params().len()) || self.abi.is_some() {
             // Parsing data from selector.
             self._local_get_calldata(local_index)
         } else {
@@ -49,7 +49,11 @@ impl Function {
 
     /// Local get from calldata.
     fn _local_get_calldata(&mut self, local_index: usize) -> Result<()> {
-        let offset = self.locals.offset_of(local_index)?;
+        let mut offset = self.locals.offset_of(local_index)?;
+        if self.abi.is_some() {
+            offset = (4 + local_index * 32).to_ls_bytes().to_vec().into();
+        }
+
         self.masm.push(&offset)?;
         self.masm._calldataload()?;
 

--- a/codegen/src/wasm/mod.rs
+++ b/codegen/src/wasm/mod.rs
@@ -106,6 +106,16 @@ impl Env {
         Err(Error::FuncNotImported(name.into()))
     }
 
+    /// Check if the input function is external function
+    pub fn is_external(&self, index: u32) -> bool {
+        let Some(name) = self.exports.get(&index) else {
+            return false;
+        };
+
+        let selector = name.to_owned() + "_selector";
+        self.exports.iter().any(|(_, n)| **n == selector)
+    }
+
     /// If the present function index is the main function
     pub fn is_main(&self, index: u32) -> bool {
         self.imports.len() as u32 == index

--- a/compiler/filetests/lib.rs
+++ b/compiler/filetests/lib.rs
@@ -31,6 +31,7 @@ impl Test {
         let mut compiler = zinkc::Compiler::default();
         // TODO: after #166
         if name == "fibonacci" {
+            // return Ok(());
             compiler.config = compiler.config.dispatcher(true);
         }
         compiler.compile(&wasm)?;

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -8,6 +8,11 @@ extern crate zink;
 /// Calculates the nth fibonacci number.
 #[zink::external]
 pub fn fib(n: u64) -> u64 {
+    internal_rec(n)
+}
+
+#[inline(never)]
+fn internal_rec(n: u64) -> u64 {
     if n < 2 {
         n
     } else {


### PR DESCRIPTION
Resolves #241 
Resolves #160 
Resolves #165 

### Changes

- [x] get locals from calldata directly in external functions
- [x] remove the processor in dispatcher

