### PR TITLE
feat(zink): introduce derive macro contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ dependencies = [
  "hex",
  "paste",
  "serde_json",
+ "smallvec",
  "tiny-keccak",
  "tracing",
  "zabi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ paste.workspace = true
 zink-codegen.workspace = true
 zink-abi-macro = { path = "zink/abi-macro", optional = true }
 zabi = { path = "zink/abi", version = "0.1.11" }
+smallvec.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tiny-keccak.workspace = true

--- a/examples/br_balance.rs
+++ b/examples/br_balance.rs
@@ -14,7 +14,6 @@ fn check_and_update(value: i32) -> bool {
     // This mimics the ERC20 balance check
     if current < value {
         zink::revert!("Not enough balance");
-        // TODO: #287
         return false;
     }
 
@@ -22,7 +21,6 @@ fn check_and_update(value: i32) -> bool {
     return true;
 }
 
-// TODO: identify if the problem is caused by control flow of incorrect opcode mapping. (issue #287)
 #[test]
 fn test_balance_check() -> anyhow::Result<()> {
     use zint::{Bytes32, Contract, EVM};

--- a/examples/contract.rs
+++ b/examples/contract.rs
@@ -126,7 +126,7 @@ fn test_storage() -> anyhow::Result<()> {
 
     let mut evm = EVM::default().commit(true).caller(caller);
     let mut contract = Contract::search("contract")?.compile()?;
-    
+
     // Convert strings to Bytes32
     let name_bytes = "The Zink Language".as_bytes();
     let mut name_array = [0u8; 32];
@@ -135,7 +135,8 @@ fn test_storage() -> anyhow::Result<()> {
 
     let symbol_bytes = "zink".as_bytes();
     let mut symbol_array = [0u8; 32];
-    symbol_array[..symbol_bytes.len().min(32)].copy_from_slice(&symbol_bytes[..symbol_bytes.len().min(32)]);
+    symbol_array[..symbol_bytes.len().min(32)]
+        .copy_from_slice(&symbol_bytes[..symbol_bytes.len().min(32)]);
     let _symbol = Bytes32(symbol_array);
 
     let total_supply_value = U256::from(42u64);
@@ -145,9 +146,18 @@ fn test_storage() -> anyhow::Result<()> {
         &contract
             .construct(
                 [
-                    (ZintU256::from(0).to_le_bytes::<32>(), SmallVec::from_slice(&name_array)),
-                    (ZintU256::from(1).to_le_bytes::<32>(), SmallVec::from_slice(&symbol_array)),
-                    (ZintU256::from(2).to_le_bytes::<32>(), SmallVec::from_slice(&total_supply_value.bytes32())),
+                    (
+                        ZintU256::from(0).to_le_bytes::<32>(),
+                        SmallVec::from_slice(&name_array),
+                    ),
+                    (
+                        ZintU256::from(1).to_le_bytes::<32>(),
+                        SmallVec::from_slice(&symbol_array),
+                    ),
+                    (
+                        ZintU256::from(2).to_le_bytes::<32>(),
+                        SmallVec::from_slice(&total_supply_value.bytes32()),
+                    ),
                 ]
                 .into_iter()
                 .map(|(k, v)| (SmallVec::from_slice(&k), v))
@@ -159,13 +169,25 @@ fn test_storage() -> anyhow::Result<()> {
 
     // Test storage directly via EVM (bypassing contract calls due to revert issue)
     let name_storage = evm.storage(address, ZintU256::from(0).to_le_bytes::<32>())?;
-    assert_eq!(name_storage.to_vec(), name_array.to_vec(), "Name storage mismatch");
+    assert_eq!(
+        name_storage.to_vec(),
+        name_array.to_vec(),
+        "Name storage mismatch"
+    );
 
     let symbol_storage = evm.storage(address, ZintU256::from(1).to_le_bytes::<32>())?;
-    assert_eq!(symbol_storage.to_vec(), symbol_array.to_vec(), "Symbol storage mismatch");
+    assert_eq!(
+        symbol_storage.to_vec(),
+        symbol_array.to_vec(),
+        "Symbol storage mismatch"
+    );
 
     let total_supply_storage = evm.storage(address, ZintU256::from(2).to_le_bytes::<32>())?;
-    assert_eq!(total_supply_storage.to_vec(), total_supply_value.bytes32().to_vec(), "Total supply storage mismatch");
+    assert_eq!(
+        total_supply_storage.to_vec(),
+        total_supply_value.bytes32().to_vec(),
+        "Total supply storage mismatch"
+    );
 
     Ok(())
 }

--- a/examples/contract.rs
+++ b/examples/contract.rs
@@ -1,0 +1,171 @@
+//! Minimal ERC20 storage test with Bytes32
+#![cfg_attr(target_arch = "wasm32", no_std)]
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+extern crate zink;
+
+use crate::zink::{DoubleKeyMapping as OtherDoubleKeyMapping, Mapping as OtherMapping, Storage};
+#[allow(unused)]
+use smallvec::SmallVec;
+use zink::primitives::{Address, Bytes32, U256};
+
+#[cfg(target_arch = "wasm32")]
+#[global_allocator]
+static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+struct Mapping<K, V>(core::marker::PhantomData<(K, V)>);
+struct DoubleKeyMapping<K1, K2, V>(core::marker::PhantomData<(K1, K2, V)>);
+
+#[allow(dead_code)]
+#[derive(zink_codegen::Storage)]
+pub struct ERC20 {
+    name: Bytes32,
+    symbol: Bytes32,
+    total_supply: U256,
+    balances: Mapping<Address, U256>,
+    allowances: DoubleKeyMapping<Address, Address, U256>,
+}
+
+impl ERC20 {
+    #[zink::external]
+    pub fn init(&self, name: Bytes32, symbol: Bytes32) {
+        self.set_name(name);
+        self.set_symbol(symbol);
+    }
+
+    #[zink::external]
+    pub fn decimals(&self) -> u32 {
+        8
+    }
+
+    #[zink::external]
+    pub fn transfer(&self, to: Address, value: U256) -> bool {
+        let owner = Address::caller();
+        self._transfer(owner, to, value);
+        true
+    }
+
+    #[zink::external]
+    pub fn approve(&self, spender: Address, value: U256) -> bool {
+        let owner = Address::caller();
+        self._approve(owner, spender, value);
+        true
+    }
+
+    #[zink::external]
+    pub fn transfer_from(&self, from: Address, to: Address, value: U256) -> bool {
+        let spender = Address::caller();
+        self._spend_allowance(from, spender, value);
+        self._transfer(from, to, value);
+        true
+    }
+
+    #[no_mangle]
+    fn _transfer(&self, from: Address, to: Address, value: U256) {
+        if from.eq(Address::empty()) {
+            zink::revert!("Empty from address");
+        }
+        if to.eq(Address::empty()) {
+            zink::revert!("Empty to address");
+        }
+        self._update(from, to, value);
+    }
+
+    #[no_mangle]
+    fn _update(&self, from: Address, to: Address, value: U256) {
+        if from.eq(Address::empty()) {
+            self.set_total_supply(self.total_supply().add(value));
+        } else {
+            let from_balance = self.balances(from);
+            if from_balance.lt(value) {
+                zink::revert!("Insufficient balance");
+            }
+            self.set_balances(from, from_balance.sub(value));
+        }
+
+        if to.eq(Address::empty()) {
+            self.set_total_supply(self.total_supply().sub(value));
+        } else {
+            self.set_total_supply(self.total_supply().add(value));
+        }
+    }
+
+    #[no_mangle]
+    fn _approve(&self, owner: Address, spender: Address, value: U256) {
+        if owner.eq(Address::empty()) {
+            zink::revert!("ERC20 Invalid approval");
+        }
+        if spender.eq(Address::empty()) {
+            zink::revert!("ERC20 Invalid spender");
+        }
+        self.set_allowances(owner, spender, value);
+    }
+
+    #[no_mangle]
+    fn _spend_allowance(&self, owner: Address, spender: Address, value: U256) {
+        let current_allowance = self.allowances(owner, spender);
+        if current_allowance.lt(U256::max()) {
+            if current_allowance.lt(value) {
+                zink::revert!("ERC20 Insufficient allowance");
+            }
+            self._approve(owner, spender, current_allowance.sub(value));
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}
+
+#[test]
+fn test_storage() -> anyhow::Result<()> {
+    use zint::{Contract, EVM, U256 as ZintU256};
+
+    let caller_bytes = hex::decode("be862ad9abfe6f22bcb087716c7d89a26051f74c")?;
+    let mut caller = [0; 20];
+    caller.copy_from_slice(&caller_bytes);
+
+    let mut evm = EVM::default().commit(true).caller(caller);
+    let mut contract = Contract::search("contract")?.compile()?;
+    
+    // Convert strings to Bytes32
+    let name_bytes = "The Zink Language".as_bytes();
+    let mut name_array = [0u8; 32];
+    name_array[..name_bytes.len().min(32)].copy_from_slice(&name_bytes[..name_bytes.len().min(32)]);
+    let _name = Bytes32(name_array);
+
+    let symbol_bytes = "zink".as_bytes();
+    let mut symbol_array = [0u8; 32];
+    symbol_array[..symbol_bytes.len().min(32)].copy_from_slice(&symbol_bytes[..symbol_bytes.len().min(32)]);
+    let _symbol = Bytes32(symbol_array);
+
+    let total_supply_value = U256::from(42u64);
+
+    // Deploy with initial storage
+    let info = evm.deploy(
+        &contract
+            .construct(
+                [
+                    (ZintU256::from(0).to_le_bytes::<32>(), SmallVec::from_slice(&name_array)),
+                    (ZintU256::from(1).to_le_bytes::<32>(), SmallVec::from_slice(&symbol_array)),
+                    (ZintU256::from(2).to_le_bytes::<32>(), SmallVec::from_slice(&total_supply_value.bytes32())),
+                ]
+                .into_iter()
+                .map(|(k, v)| (SmallVec::from_slice(&k), v))
+                .collect(),
+            )?
+            .bytecode()?,
+    )?;
+    let address = info.address;
+
+    // Test storage directly via EVM (bypassing contract calls due to revert issue)
+    let name_storage = evm.storage(address, ZintU256::from(0).to_le_bytes::<32>())?;
+    assert_eq!(name_storage.to_vec(), name_array.to_vec(), "Name storage mismatch");
+
+    let symbol_storage = evm.storage(address, ZintU256::from(1).to_le_bytes::<32>())?;
+    assert_eq!(symbol_storage.to_vec(), symbol_array.to_vec(), "Symbol storage mismatch");
+
+    let total_supply_storage = evm.storage(address, ZintU256::from(2).to_le_bytes::<32>())?;
+    assert_eq!(total_supply_storage.to_vec(), total_supply_value.bytes32().to_vec(), "Total supply storage mismatch");
+
+    Ok(())
+}

--- a/examples/getter.rs
+++ b/examples/getter.rs
@@ -1,0 +1,82 @@
+//! Simple getter example to debug dispatcher
+#![cfg_attr(target_arch = "wasm32", no_std)]
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+extern crate zink;
+
+use zink::primitives::Bytes32;
+use zink::Storage;
+
+#[allow(dead_code)]
+#[derive(zink_codegen::Storage)]
+pub struct Getter {
+    value: Bytes32,
+}
+
+impl Getter {
+    #[zink::external]
+    pub fn get_value(&self) -> Bytes32 {
+        self.value()
+    }
+
+    #[zink::external]
+    pub fn init(&self, value: Bytes32) {
+        self.set_value(value);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_getter() -> anyhow::Result<()> {
+    #[allow(unused)]
+    use smallvec::SmallVec;
+    use zint::{Contract, EVM, U256 as ZintU256};
+
+    let caller_bytes = hex::decode("be862ad9abfe6f22bcb087716c7d89a26051f74c")?;
+    let mut caller = [0; 20];
+    caller.copy_from_slice(&caller_bytes);
+
+    let mut evm = EVM::default().commit(true).caller(caller);
+    let mut contract = Contract::search("getter")?.compile()?;
+
+    let value_bytes = "TestValue".as_bytes();
+    let mut value_array = [0u8; 32];
+    value_array[..value_bytes.len().min(32)]
+        .copy_from_slice(&value_bytes[..value_bytes.len().min(32)]);
+    let _value = Bytes32(value_array);
+
+    // Deploy with initial value
+    let info = evm.deploy(
+        &contract
+            .construct(
+                [(
+                    ZintU256::from(0).to_le_bytes::<32>(),
+                    SmallVec::from_slice(&value_array),
+                )]
+                .into_iter()
+                .map(|(k, v)| (SmallVec::from_slice(&k), v))
+                .collect(),
+            )?
+            .bytecode()?,
+    )?;
+    let address = info.address;
+
+    // Test direct storage read
+    let stored_value = evm.storage(address, ZintU256::from(0).to_le_bytes::<32>())?;
+    assert_eq!(
+        stored_value.to_vec(),
+        value_array.to_vec(),
+        "Storage mismatch"
+    );
+
+    // Test runtime getter
+    let info = evm
+        .calldata(&contract.encode(&[b"get_value()".to_vec()])?)
+        .call(address)?;
+    assert_eq!(info.ret, value_array.to_vec(), "Getter failed: {:?}", info);
+
+    Ok(())
+}

--- a/zink/codegen/src/contract.rs
+++ b/zink/codegen/src/contract.rs
@@ -1,0 +1,275 @@
+//! Derive macro for contract storage
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Fields, ItemStruct, Type};
+
+/// Parse the input struct and generate the contract storage implementation
+pub fn parse(input: ItemStruct) -> TokenStream {
+    let Fields::Named(fields) = &input.fields else {
+        return syn::Error::new(
+            Span::call_site(),
+            "Storage derive only supports structs with named fields",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let struct_name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut slot_counter = 0;
+    let field_structs: Vec<_> = fields.named.iter().map(|field| {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_ty = &field.ty;
+        let slot = slot_counter;
+        slot_counter += 1;
+        // Concatenate without space for valid identifier
+        let struct_name = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
+
+        match classify_field_type(field_ty) {
+            FieldType::Simple => {
+                quote! {
+                    pub struct #struct_name;
+                    impl #impl_generics zink::storage::Storage for #struct_name #ty_generics #where_clause {
+                        const STORAGE_SLOT: i32 = #slot;
+                        type Value = #field_ty;
+
+                        #[cfg(not(target_family = "wasm"))]
+                        const STORAGE_KEY: [u8; 32] = [0u8; 32];
+
+                        fn get() -> Self::Value {
+                            zink::Asm::push(Self::STORAGE_SLOT);
+                            <Self::Value as zink::storage::StorageValue>::sload()
+                        }
+
+                        fn set(value: Self::Value) {
+                            value.push();
+                            zink::Asm::push(Self::STORAGE_SLOT);
+                            unsafe { zink::ffi::evm::sstore(); }
+                        }
+                    }
+                }
+            }
+            FieldType::Mapping => {
+                let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap_or_else(|| {
+                    panic!("Mapping type must be of form Mapping<K, V>");
+                });
+                quote! {
+                    pub struct #struct_name;
+                    impl #impl_generics zink::storage::Mapping for #struct_name #ty_generics #where_clause {
+                        const STORAGE_SLOT: i32 = #slot;
+                        type Key = #key_ty;
+                        type Value = #value_ty;
+
+                        #[cfg(not(target_family = "wasm"))]
+                        fn storage_key(key: Self::Key) -> [u8; 32] {
+                            [0u8; 32]
+                        }
+
+                        fn get(key: Self::Key) -> Self::Value {
+                            zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
+                            <Self::Value as zink::storage::StorageValue>::sload()
+                        }
+
+                        fn set(key: Self::Key, value: Self::Value) {
+                            value.push();
+                            zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
+                            unsafe { zink::ffi::evm::sstore(); }
+                        }
+                    }
+                }
+            }
+            FieldType::DoubleKeyMapping => {
+                let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap_or_else(|| {
+                    panic!("DoubleKeyMapping type must be of form DoubleKeyMapping<K1, K2, V>");
+                });
+                quote! {
+                    pub struct #struct_name;
+                    impl #impl_generics zink::storage::DoubleKeyMapping for #struct_name #ty_generics #where_clause {
+                        const STORAGE_SLOT: i32 = #slot;
+                        type Key1 = #key1_ty;
+                        type Key2 = #key2_ty;
+                        type Value = #value_ty;
+
+                        #[cfg(not(target_family = "wasm"))]
+                        fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32] {
+                            [0u8; 32]
+                        }
+
+                        fn get(key1: Self::Key1, key2: Self::Key2) -> Self::Value {
+                            zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
+                            <Self::Value as zink::storage::StorageValue>::sload()
+                        }
+
+                        fn set(key1: Self::Key1, key2: Self::Key2, value: Self::Value) {
+                            value.push();
+                            zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
+                            unsafe { zink::ffi::evm::sstore(); }
+                        }
+                    }
+                }
+            }
+            FieldType::Unknown => {
+                syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
+            }
+        }
+    }).collect();
+
+    let method_impls: Vec<_> = fields.named.iter().map(|field| {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_ty = &field.ty;
+        let setter_name = format_ident!("set_{}", field_name);
+        let field_struct = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
+
+        match classify_field_type(field_ty) {
+            FieldType::Simple => {
+                quote! {
+                    pub fn #field_name(&self) -> #field_ty {
+                        #field_struct::get()
+                    }
+
+                    pub fn #setter_name(&self, value: #field_ty) {
+                        #field_struct::set(value);
+                    }
+                }
+            }
+            FieldType::Mapping => {
+                let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap();
+                quote! {
+                    pub fn #field_name(&self, key: #key_ty) -> #value_ty {
+                        #field_struct::get(key)
+                    }
+
+                    pub fn #setter_name(&self, key: #key_ty, value: #value_ty) {
+                        #field_struct::set(key, value);
+                    }
+                }
+            }
+            FieldType::DoubleKeyMapping => {
+                let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap();
+                quote! {
+                    pub fn #field_name(&self, key1: #key1_ty, key2: #key2_ty) -> #value_ty {
+                        #field_struct::get(key1, key2)
+                    }
+
+                    pub fn #setter_name(&self, key1: #key1_ty, key2: #key2_ty, value: #value_ty) {
+                        #field_struct::set(key1, key2, value);
+                    }
+                }
+            }
+            FieldType::Unknown => {
+                syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
+            }
+        }
+    }).collect();
+
+    let expanded = quote! {
+        use zink::Asm; // Import Asm for push method
+
+        #(#field_structs)*
+
+        impl #impl_generics #struct_name #ty_generics #where_clause {
+            #(#method_impls)*
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+trait ToUpperCamelCase {
+    fn to_upper_camel_case(&self) -> String;
+}
+
+impl ToUpperCamelCase for syn::Ident {
+    fn to_upper_camel_case(&self) -> String {
+        let s = self.to_string();
+        let mut result = String::new();
+        let mut capitalize_next = true;
+
+        for c in s.chars() {
+            if c == '_' {
+                capitalize_next = true;
+            } else if capitalize_next {
+                result.push(c.to_ascii_uppercase());
+                capitalize_next = false;
+            } else {
+                result.push(c);
+            }
+        }
+        result
+    }
+}
+
+/// Classify the field type to determine the appropriate storage trait
+fn classify_field_type(ty: &Type) -> FieldType {
+    if let Type::Path(type_path) = ty {
+        let path = &type_path.path;
+        if let Some(segment) = path.segments.last() {
+            match segment.ident.to_string().as_str() {
+                "Mapping" => FieldType::Mapping,
+                "DoubleKeyMapping" => FieldType::DoubleKeyMapping,
+                _ => FieldType::Simple,
+            }
+        } else {
+            FieldType::Unknown
+        }
+    } else {
+        FieldType::Unknown
+    }
+}
+
+/// Extract generic types from Mapping<K, V>
+fn extract_mapping_types(ty: &Type) -> Option<(Type, Type)> {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            if segment.ident == "Mapping" {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    let args: Vec<_> = args.args.iter().collect();
+                    if args.len() == 2 {
+                        if let (
+                            syn::GenericArgument::Type(key_ty),
+                            syn::GenericArgument::Type(value_ty),
+                        ) = (&args[0], &args[1])
+                        {
+                            return Some((key_ty.clone(), value_ty.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract generic types from DoubleKeyMapping<K1, K2, V>
+fn extract_double_key_mapping_types(ty: &Type) -> Option<(Type, Type, Type)> {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            if segment.ident == "DoubleKeyMapping" {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    let args: Vec<_> = args.args.iter().collect();
+                    if args.len() == 3 {
+                        if let (
+                            syn::GenericArgument::Type(key1_ty),
+                            syn::GenericArgument::Type(key2_ty),
+                            syn::GenericArgument::Type(value_ty),
+                        ) = (&args[0], &args[1], &args[2])
+                        {
+                            return Some((key1_ty.clone(), key2_ty.clone(), value_ty.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+enum FieldType {
+    Simple,
+    Mapping,
+    DoubleKeyMapping,
+    Unknown,
+}

--- a/zink/codegen/src/contract.rs
+++ b/zink/codegen/src/contract.rs
@@ -2,187 +2,203 @@
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Fields, ItemStruct, Type};
+use syn::{parse_macro_input, Fields, Ident, ItemStruct, Type};
 
-/// Parse the input struct and generate the contract storage implementation
-pub fn parse(input: ItemStruct) -> TokenStream {
-    let Fields::Named(fields) = &input.fields else {
-        return syn::Error::new(
-            Span::call_site(),
-            "Storage derive only supports structs with named fields",
-        )
-        .to_compile_error()
-        .into();
-    };
+// Represents the contract storage derivation
+pub struct ContractStorage {
+    target: ItemStruct,
+}
 
-    let struct_name = &input.ident;
-    let generics = &input.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+impl ContractStorage {
+    /// Create a new ContractStorage from an input struct
+    pub fn new(input: ItemStruct) -> Self {
+        Self { target: input }
+    }
 
-    let mut slot_counter = 0;
-    let field_structs: Vec<_> = fields.named.iter().map(|field| {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let slot = slot_counter;
-        slot_counter += 1;
-        // Concatenate without space for valid identifier
-        let struct_name = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
+    /// Parse and validate the input, returning a TokenStream
+    pub fn parse(input: TokenStream) -> TokenStream {
+        let input = parse_macro_input!(input as ItemStruct);
+        let storage = Self::new(input);
+        storage.expand()
+    }
 
-        match classify_field_type(field_ty) {
-            FieldType::Simple => {
-                quote! {
-                    pub struct #struct_name;
-                    impl #impl_generics zink::storage::Storage for #struct_name #ty_generics #where_clause {
-                        const STORAGE_SLOT: i32 = #slot;
-                        type Value = #field_ty;
+    /// Generate the expanded TokenStream
+    fn expand(&self) -> TokenStream {
+        let Fields::Named(fields) = &self.target.fields else {
+            return syn::Error::new(
+                Span::call_site(),
+                "Storage derive only supports structs with named fields",
+            )
+            .to_compile_error()
+            .into();
+        };
 
-                        #[cfg(not(target_family = "wasm"))]
-                        const STORAGE_KEY: [u8; 32] = [0u8; 32];
+        let struct_name = &self.target.ident;
+        let generics = &self.target.generics;
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-                        fn get() -> Self::Value {
-                            zink::Asm::push(Self::STORAGE_SLOT);
-                            <Self::Value as zink::storage::StorageValue>::sload()
-                        }
+        let mut slot_counter = 0;
+        let field_structs: Vec<_> = fields.named.iter().map(|field| {
+            let field_name = field.ident.as_ref().unwrap();
+            let field_ty = &field.ty;
+            let slot = slot_counter;
+            slot_counter += 1;
+            let struct_name = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
 
-                        fn set(value: Self::Value) {
-                            value.push();
-                            zink::Asm::push(Self::STORAGE_SLOT);
-                            unsafe { zink::ffi::evm::sstore(); }
-                        }
-                    }
-                }
-            }
-            FieldType::Mapping => {
-                let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap_or_else(|| {
-                    panic!("Mapping type must be of form Mapping<K, V>");
-                });
-                quote! {
-                    pub struct #struct_name;
-                    impl #impl_generics zink::storage::Mapping for #struct_name #ty_generics #where_clause {
-                        const STORAGE_SLOT: i32 = #slot;
-                        type Key = #key_ty;
-                        type Value = #value_ty;
+            match classify_field_type(field_ty) {
+                FieldType::Simple => {
+                    quote! {
+                        pub struct #struct_name;
+                        impl #impl_generics zink::storage::Storage for #struct_name #ty_generics #where_clause {
+                            const STORAGE_SLOT: i32 = #slot;
+                            type Value = #field_ty;
 
-                        #[cfg(not(target_family = "wasm"))]
-                        fn storage_key(key: Self::Key) -> [u8; 32] {
-                            [0u8; 32]
-                        }
+                            #[cfg(not(target_family = "wasm"))]
+                            const STORAGE_KEY: [u8; 32] = [0u8; 32];
 
-                        fn get(key: Self::Key) -> Self::Value {
-                            zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
-                            <Self::Value as zink::storage::StorageValue>::sload()
-                        }
+                            fn get() -> Self::Value {
+                                zink::Asm::push(Self::STORAGE_SLOT);
+                                <Self::Value as zink::storage::StorageValue>::sload()
+                            }
 
-                        fn set(key: Self::Key, value: Self::Value) {
-                            value.push();
-                            zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
-                            unsafe { zink::ffi::evm::sstore(); }
+                            fn set(value: Self::Value) {
+                                value.push();
+                                zink::Asm::push(Self::STORAGE_SLOT);
+                                unsafe { zink::ffi::evm::sstore(); }
+                            }
                         }
                     }
                 }
-            }
-            FieldType::DoubleKeyMapping => {
-                let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap_or_else(|| {
-                    panic!("DoubleKeyMapping type must be of form DoubleKeyMapping<K1, K2, V>");
-                });
-                quote! {
-                    pub struct #struct_name;
-                    impl #impl_generics zink::storage::DoubleKeyMapping for #struct_name #ty_generics #where_clause {
-                        const STORAGE_SLOT: i32 = #slot;
-                        type Key1 = #key1_ty;
-                        type Key2 = #key2_ty;
-                        type Value = #value_ty;
+                FieldType::Mapping => {
+                    let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap_or_else(|| {
+                        panic!("Mapping type must be of form Mapping<K, V>");
+                    });
+                    quote! {
+                        pub struct #struct_name;
+                        impl #impl_generics zink::storage::Mapping for #struct_name #ty_generics #where_clause {
+                            const STORAGE_SLOT: i32 = #slot;
+                            type Key = #key_ty;
+                            type Value = #value_ty;
 
-                        #[cfg(not(target_family = "wasm"))]
-                        fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32] {
-                            [0u8; 32]
+                            #[cfg(not(target_family = "wasm"))]
+                            fn storage_key(key: Self::Key) -> [u8; 32] {
+                                [0u8; 32]
+                            }
+
+                            fn get(key: Self::Key) -> Self::Value {
+                                zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
+                                <Self::Value as zink::storage::StorageValue>::sload()
+                            }
+
+                            fn set(key: Self::Key, value: Self::Value) {
+                                value.push();
+                                zink::storage::mapping::load_key(key, Self::STORAGE_SLOT);
+                                unsafe { zink::ffi::evm::sstore(); }
+                            }
+                        }
+                    }
+                }
+                FieldType::DoubleKeyMapping => {
+                    let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap_or_else(|| {
+                        panic!("DoubleKeyMapping type must be of form DoubleKeyMapping<K1, K2, V>");
+                    });
+                    quote! {
+                        pub struct #struct_name;
+                        impl #impl_generics zink::storage::DoubleKeyMapping for #struct_name #ty_generics #where_clause {
+                            const STORAGE_SLOT: i32 = #slot;
+                            type Key1 = #key1_ty;
+                            type Key2 = #key2_ty;
+                            type Value = #value_ty;
+
+                            #[cfg(not(target_family = "wasm"))]
+                            fn storage_key(key1: Self::Key1, key2: Self::Key2) -> [u8; 32] {
+                                [0u8; 32]
+                            }
+
+                            fn get(key1: Self::Key1, key2: Self::Key2) -> Self::Value {
+                                zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
+                                <Self::Value as zink::storage::StorageValue>::sload()
+                            }
+
+                            fn set(key1: Self::Key1, key2: Self::Key2, value: Self::Value) {
+                                value.push();
+                                zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
+                                unsafe { zink::ffi::evm::sstore(); }
+                            }
+                        }
+                    }
+                }
+                FieldType::Unknown => {
+                    syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
+                }
+            }
+        }).collect();
+
+        let method_impls: Vec<_> = fields.named.iter().map(|field| {
+            let field_name = field.ident.as_ref().unwrap();
+            let field_ty = &field.ty;
+            let setter_name = format_ident!("set_{}", field_name);
+            let field_struct = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
+
+            match classify_field_type(field_ty) {
+                FieldType::Simple => {
+                    quote! {
+                        pub fn #field_name(&self) -> #field_ty {
+                            #field_struct::get()
                         }
 
-                        fn get(key1: Self::Key1, key2: Self::Key2) -> Self::Value {
-                            zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
-                            <Self::Value as zink::storage::StorageValue>::sload()
-                        }
-
-                        fn set(key1: Self::Key1, key2: Self::Key2, value: Self::Value) {
-                            value.push();
-                            zink::storage::dkmapping::load_double_key(key1, key2, Self::STORAGE_SLOT);
-                            unsafe { zink::ffi::evm::sstore(); }
+                        pub fn #setter_name(&self, value: #field_ty) {
+                            #field_struct::set(value);
                         }
                     }
                 }
-            }
-            FieldType::Unknown => {
-                syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
-            }
-        }
-    }).collect();
+                FieldType::Mapping => {
+                    let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap();
+                    quote! {
+                        pub fn #field_name(&self, key: #key_ty) -> #value_ty {
+                            #field_struct::get(key)
+                        }
 
-    let method_impls: Vec<_> = fields.named.iter().map(|field| {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let setter_name = format_ident!("set_{}", field_name);
-        let field_struct = format_ident!("{}{}", struct_name, field_name.to_upper_camel_case());
-
-        match classify_field_type(field_ty) {
-            FieldType::Simple => {
-                quote! {
-                    pub fn #field_name(&self) -> #field_ty {
-                        #field_struct::get()
-                    }
-
-                    pub fn #setter_name(&self, value: #field_ty) {
-                        #field_struct::set(value);
+                        pub fn #setter_name(&self, key: #key_ty, value: #value_ty) {
+                            #field_struct::set(key, value);
+                        }
                     }
                 }
-            }
-            FieldType::Mapping => {
-                let (key_ty, value_ty) = extract_mapping_types(field_ty).unwrap();
-                quote! {
-                    pub fn #field_name(&self, key: #key_ty) -> #value_ty {
-                        #field_struct::get(key)
-                    }
+                FieldType::DoubleKeyMapping => {
+                    let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap();
+                    quote! {
+                        pub fn #field_name(&self, key1: #key1_ty, key2: #key2_ty) -> #value_ty {
+                            #field_struct::get(key1, key2)
+                        }
 
-                    pub fn #setter_name(&self, key: #key_ty, value: #value_ty) {
-                        #field_struct::set(key, value);
-                    }
-                }
-            }
-            FieldType::DoubleKeyMapping => {
-                let (key1_ty, key2_ty, value_ty) = extract_double_key_mapping_types(field_ty).unwrap();
-                quote! {
-                    pub fn #field_name(&self, key1: #key1_ty, key2: #key2_ty) -> #value_ty {
-                        #field_struct::get(key1, key2)
-                    }
-
-                    pub fn #setter_name(&self, key1: #key1_ty, key2: #key2_ty, value: #value_ty) {
-                        #field_struct::set(key1, key2, value);
+                        pub fn #setter_name(&self, key1: #key1_ty, key2: #key2_ty, value: #value_ty) {
+                            #field_struct::set(key1, key2, value);
+                        }
                     }
                 }
+                FieldType::Unknown => {
+                    syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
+                }
             }
-            FieldType::Unknown => {
-                syn::Error::new_spanned(field_ty, "Unsupported storage type").to_compile_error()
+        }).collect();
+
+        let expanded = quote! {
+            use zink::Asm;
+            #(#field_structs)*
+            impl #impl_generics #struct_name #ty_generics #where_clause {
+                #(#method_impls)*
             }
-        }
-    }).collect();
+        };
 
-    let expanded = quote! {
-        use zink::Asm; // Import Asm for push method
-
-        #(#field_structs)*
-
-        impl #impl_generics #struct_name #ty_generics #where_clause {
-            #(#method_impls)*
-        }
-    };
-
-    TokenStream::from(expanded)
+        TokenStream::from(expanded)
+    }
 }
 
 trait ToUpperCamelCase {
     fn to_upper_camel_case(&self) -> String;
 }
 
-impl ToUpperCamelCase for syn::Ident {
+impl ToUpperCamelCase for Ident {
     fn to_upper_camel_case(&self) -> String {
         let s = self.to_string();
         let mut result = String::new();
@@ -202,7 +218,13 @@ impl ToUpperCamelCase for syn::Ident {
     }
 }
 
-/// Classify the field type to determine the appropriate storage trait
+enum FieldType {
+    Simple,
+    Mapping,
+    DoubleKeyMapping,
+    Unknown,
+}
+
 fn classify_field_type(ty: &Type) -> FieldType {
     if let Type::Path(type_path) = ty {
         let path = &type_path.path;
@@ -265,11 +287,4 @@ fn extract_double_key_mapping_types(ty: &Type) -> Option<(Type, Type, Type)> {
         }
     }
     None
-}
-
-enum FieldType {
-    Simple,
-    Mapping,
-    DoubleKeyMapping,
-    Unknown,
 }

--- a/zink/codegen/src/lib.rs
+++ b/zink/codegen/src/lib.rs
@@ -8,6 +8,7 @@ use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{parse_macro_input, Attribute, DeriveInput, Expr, ItemFn, ItemStruct, LitStr};
 
+mod contract;
 mod event;
 mod revert;
 mod selector;
@@ -31,6 +32,13 @@ pub fn revert(input: TokenStream) -> TokenStream {
 pub fn assert(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as revert::AssertInput);
     revert::parse_assert(input)
+}
+
+/// Declare contract storage
+#[proc_macro_derive(Storage)]
+pub fn storage_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    contract::parse(input)
 }
 
 /// Event logging interface

--- a/zink/codegen/src/lib.rs
+++ b/zink/codegen/src/lib.rs
@@ -37,8 +37,7 @@ pub fn assert(input: TokenStream) -> TokenStream {
 /// Declare contract storage
 #[proc_macro_derive(Storage)]
 pub fn storage_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
-    contract::parse(input)
+    contract::ContractStorage::parse(input)
 }
 
 /// Event logging interface

--- a/zink/src/lib.rs
+++ b/zink/src/lib.rs
@@ -12,7 +12,7 @@ pub mod primitives;
 pub mod storage;
 pub use self::{asm::Asm, event::Event};
 pub use storage::{DoubleKeyMapping, Mapping, Storage, TransientStorage};
-pub use zink_codegen::{assert, external, revert, storage, transient_storage, Event};
+pub use zink_codegen::{assert, external, revert, storage, transient_storage, Event, Storage};
 
 #[cfg(feature = "abi-import")]
 pub use zink_abi_macro::import;

--- a/zink/src/storage/dkmapping.rs
+++ b/zink/src/storage/dkmapping.rs
@@ -66,7 +66,7 @@ pub trait DoubleKeyTransientMapping {
 
 /// Load storage key to stack
 #[inline(always)]
-fn load_double_key(key1: impl Asm, key2: impl Asm, index: i32) {
+pub fn load_double_key(key1: impl Asm, key2: impl Asm, index: i32) {
     unsafe {
         ffi::label_reserve_mem_64();
 

--- a/zink/src/storage/mapping.rs
+++ b/zink/src/storage/mapping.rs
@@ -59,7 +59,7 @@ pub trait TransientMapping {
 }
 
 /// Load storage key to stack
-fn load_key(key: impl Asm, index: i32) {
+pub fn load_key(key: impl Asm, index: i32) {
     unsafe {
         ffi::label_reserve_mem_32();
 

--- a/zink/src/storage/mod.rs
+++ b/zink/src/storage/mod.rs
@@ -7,8 +7,8 @@ pub use {
     value::{Storage, TransientStorage},
 };
 
-mod dkmapping;
-mod mapping;
+pub mod dkmapping;
+pub mod mapping;
 mod value;
 
 /// Interface for the value of kv based storage


### PR DESCRIPTION
resolves #288 

i made some choices i think you should be aware of

### storage type choice: `Bytes32` Over `String32`

i opted for `Bytes32` for fields like `name` and `symbol` instead of `String32` (aliased to `U256`) due to API constraints in `zink::primitives::U256`. initially, I attempted to use `String32` to align with the original ERC20 intent:

```rust
// Failed attempt with String32
let name = U256(Bytes32::from_slice_unchecked(&name_array)); // String32 is U256
```

this failed because:
`Bytes32::from_slice_unchecked` is not available in `zink::primitives::Bytes32` (only `empty()` and `eq()` exist per `impl_bytes!` in `bytes.rs`)

`U256 Private Field`: U256(Bytes32) constructor isn’t public (`pub struct U256(Bytes32)` has a private field), and no `from_big_endian` or `from_little_endian methods` exist—only `From<u64>`, `empty()`, and `max()` are available.

switching to Bytes32 resolved this:

```rust
let name = Bytes32(name_array);
```
now, `Bytes32` directly wraps `[u8; 32]` in non-WASM (via `impl_bytes!`), and the macro generates `ERC20Name::get()` as a simple `sload`, expecting a Bytes32 value. this avoids `U256`’s construction issues and matches the storage slot format (`[u8; 32]`).

### bypassing contract calls to avoid revert
the test (`test_storage`) uses direct `evm.storage()` reads instead of contract calls like `name()`:

```rust
let name_storage = evm.storage(address, ZintU256::from(0).to_le_bytes::<32>())?;
assert_eq!(name_storage.to_vec(), name_array.to_vec(), "Name storage mismatch");
```
this was necessary because runtime calls consistently reverted:

```rust
// Failed runtime call
let name_ret = evm.calldata(&contract.encode(&[b"name()".to_vec()])?).call(address)?;
assert_eq!(name_ret.ret, name_array.to_vec(), "Name mismatch: {name_ret:?}");
// Output: revert: Some("Empty from address")
```
revert Cause: the message "Empty from address" originates from _transfer:
```rust
fn _transfer(&self, from: Address, to: Address, value: U256) {
    if from.eq(Address::empty()) {
        zink::revert!("Empty from address");
    }
    // ...
}
```
unexpected trigger: `name()` (self.name() -> ERC20Name::get()) is a storage read (sload at slot 0), yet it reverts with this message. which i think (not sure) is a dispatcher issue in zinkc.

direct `evm.storage()` reads `slot 0 (name)`, `1 (symbol)`, and `2 (total_supply)` without WASM execution, confirming the macro’s `construct()` sets storage correctly. this isolates the problem to runtime dispatch, not storage setup.

the runtime revert is a blocker for testing core logic (`transfer(), approve()`). It seems `zinkc` misroutes external calls (e.g., `name()` selector `0x06fdde03`) to `_transfer (0xa9059cbb)`, unlike erc20.rs where separate structs work fine. could this be:

a dispatcher bug in selector::external or zinkc bytecode generation?

a problem with unified structs vs. separate ones?

i’d love your take on this—any ideas on why `_transfer` is hijacking calls? maybe a peek at the WASM output or dispatcher logic could shed light? 

i’ve kept the test minimal to prove storage, but i really want to get runtime calls working.