### PR TITLE
docs: fix markdown formatting in log parsing example

### DIFF
--- a/codegen/src/visitor/log.rs
+++ b/codegen/src/visitor/log.rs
@@ -6,7 +6,7 @@ impl Function {
     /// Parse log data from the bytecode.
     ///
     /// WASM example:
-    /// ```
+    /// ```text
     /// i32.const 1048576   ;; offset
     /// i32.const 4         ;; 4 bytes
     /// ```


### PR DESCRIPTION
Resolves #337 

The triple backticks were missing the language annotation, which could cause rendering issues in the documentation. Adding `text` ensures correct syntax highlighting for the WASM example.



